### PR TITLE
Add support for reusable encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Unit Tests](https://github.com/keymask/keymask-base41/actions/workflows/test.yml/badge.svg)](https://github.com/keymask/keymask-base41/actions/workflows/test.yml)
 
-`Keymask-Base41` is a dependency-free Typescript/JavaScript utility that maps
+`Keymask-Base41` is a dependency-free JavaScript (Typescript) utility that maps
 integers up to 64 bits in length to compact, random-looking character strings.
 
 Values are first transformed by a Linear Congruential Generator so as to
-obfuscate the underlying number sequence, then the output is encoded using a
+conceal the underlying number sequence, then the result is encoded using a
 Base41 encoding scheme.
 
 ```
@@ -21,10 +21,10 @@ doesn't know the seed to reverse map the encoded values.
 
 ## Motivation
 
-Serial numbers and sequential database IDs are extremely convenient and useful,
-however, when displayed publicly they can leak information about system
-internals, such as how old a given record is, or the frequency of record
-creation (see
+Serial numbers and sequential database IDs are extremely convenient and useful
+for record-keeping, however, when displayed publicly they can leak information
+about system internals, such as how old a given record is, or the frequency of
+record creation (see
 ["German tank problem"](https://search.brave.com/search?q=german+tank+problem)).
 
 `Keymask-Base41` encodes serial numbers in such a way that they can be
@@ -32,13 +32,13 @@ displayed to end-users without revealing these kinds of details.
 
 ## Why Base41?
 
-**TL;DR:** Efficient, URL-safe, free of visualy similar characters, extremely
-unikely to form recognizable words or phrases.
+**TL;DR:** Efficient, URL-safe, free of visualy similar characters, virtually
+impossible to form recognizable words or phrases.
 
 Base41 is a highly efficient encoding for 16-, 32- and 64-bit values,
-comparable to Base57 or Base85 in this respect. Whereas Base85 encodes 64 bits
-to 10 characters, Base41 requires 12 characters. (Note that the decimal
-representation of a 64-bit value requires 20 characters and the hexadecimal, 16
+comparable to Base57 or Base85 in this respect. Whereas Base85 encodes 32 bits
+to 5 characters, Base41 requires 6 characters. (Note that the decimal
+representation of a 32-bit value requires 10 characters and the hexadecimal, 8
 characters. It can therefore be said that Base41 is 25% more efficient than
 hexadecimal and 40% more efficient than decimal, but 20% *less* efficient than
 Base85.)
@@ -46,9 +46,8 @@ Base85.)
 The primary advantage that Base41 holds over Base85 is that it is free of any
 special characters, which makes it suitable for use in URLs or other places
 where non-alphanumeric characters have special meanings or functions. Base85 is
-more compact, but less versatile, as its output will sometimes need to be
-further encoded or escaped. Base85 encodings are also more difficult to
-communicate verbally.
+more compact, but its output will sometimes need to be further encoded or
+escaped. Base85 encodings are also more difficult to communicate verbally.
 
 For its part, Base57 (or the somewhat more common Base58) is also free of
 special characters, therefore URL-safe. However, since it includes virtually
@@ -72,51 +71,63 @@ manager (npm, yarn, pnpm...).
 ## Usage
 
 The module exports three classes, `Keymask`, `Generator` (the LCG) and
-`Base41` (the encoder). The LCG and encoder can be used independently of each
-other if need be. However, the main `Keymask` class presents a simple unified
-interface to the supporting classes and will typically be all you need.
+`Base41` (the encoder). For basic use cases, the main `Keymask` class should be
+all you need, as it provides a unified interface to the other two.
 
 The `Keymask` class constructor can be passed an object containing various
-optional settings, described below. The default constructor will create an
-instance that encodes variable-length outputs (the output length will depend on
-the magnitude of the input value), while decoded values will be returned as
-either a `number` or a `bigint`, depending again on the magnitude of the value.
+optional settings, as outlined in the following sections. The default
+constructor will create an instance that encodes variable-length outputs (the
+output length will depend on the magnitude of the input value), while decoded
+values will be returned as either a `number` or a `bigint`, depending again on
+the magnitude of the value.
 
-**Example**
+**Options**
+
+```JavaScript
+type KeymaskOptions = {
+  seed?: ArrayBufferLike | ArrayBufferView;
+  size?: number | number[];
+  bigint?: boolean;
+  encoder?: Base41;
+};
+```
+
+**Example (Default settings, no seed, variable outputs)**
 
 ```JavaScript
 import { Keymask } from "keymask-base41";
 
 const keymask = new Keymask();
 
-const masked = keymask.mask(123456789);
-const unmasked = keymask.unmask(masked);
-
-console.log(masked); // "wMjMGR"
-console.log(unmasked); // 123456789
+const masked = keymask.mask(123456789); // "wMjMGR"
+const unmasked = keymask.unmask(masked); // 123456789
 ```
 
 ### `seed`
 
-If a seed value is provided, it will be used to initialize the LCG and/or
+If a `seed` value is provided, it will be used to initialize the LCG and/or
 shuffle the Base41 encoding alphabet. The value must be either an `ArrayBuffer`
 or an `ArrayBufferView`. Typically, it should be `32` bytes long, as this
-allows both the LCG and the Base41 encoding to be customized. If it is longer
+allows both the LCG and the `Base41` encoding to be customized. If it is longer
 than `32` bytes, only the first `32` bytes will be used.
 
-If the seed is *less* than `32` bytes, then only one or the other of the LCG or
-the Base41 encoding will be seeded: if the seed is less than `24` bytes, then
-the first `8` bytes will be used to initialize the LCG; if it is between `24`
-and `31` bytes, then the first `24` bytes will be used to shuffle the Base41
-encoding alphabet. Seeds less than `8` bytes long will be ignored.
+Note, however, that if a preconfigured `Base41` encoder is provided to the
+`Keymask` constructor (see `encoder` option below), the seed only needs to be
+`8` bytes long, and will be used solely to customize the LCG `Generator`. In
+this case, if more than `8` bytes are provided, only the first `8` bytes will
+be used.
 
-Providing a full, randomized `32`-byte `seed` is highly recommended, as it
-means the mappings between inputs and outputs will be extremely difficult to
-predict. If possible, the `seed` should be kept secret. However, it should
-generally not change for the lifetime of your application (doing so would make
-it impossible to unmask previously masked values).
+The `seed` should therefore be either `32` or `8` bytes long, depending on
+whether a preconfigured `Base41` encoder is used. (Note that seeding the
+encoder itself requires `24` bytes.)
 
-**Example**
+Providing a randomized `seed` is highly recommended, as this makes the mappings
+between inputs and outputs extremely difficult to predict (unless you know the
+`seed`). If possible, the `seed` should be kept secret, but it should generally
+not change for the lifetime of your application (doing so would make it
+impossible to unmask previously masked values).
+
+**Example (Seeded)**
 
 ```JavaScript
 import { Keymask } from "keymask-base41";
@@ -128,55 +139,40 @@ const keymask = new Keymask({
   ])
 });
 
-const masked = keymask.mask(123456789);
-const unmasked = keymask.unmask(masked);
-
-console.log(masked); // "KbxsJQ"
-console.log(unmasked); // 123456789
+const masked = keymask.mask(123456789); // "KbxsJQ"
+const unmasked = keymask.unmask(masked); // 123456789
 
 ```
 
-### `outputs`
+### `size`
 
 The output length(s) can be explicitly defined by providing a number or an
-array of numbers to the `outputs` option. If it is a single number, it defines
-the minimum output length; values that exceed this minimum length will scale
+array of numbers to the `size` option. If this is a single number, it defines
+the *minimum* output length; values that exceed this minimum length will scale
 automatically, with additional characters added as needed.
 
-If an array of numbers is provided, they will define successive allowable
-output lengths. If the highest provided output length is less than 12, longer
-outputs will scale automatically, as above. If you do not want this
-auto-scaling behavior, be sure to include `12` as the last value in the array.
+If an array of numbers is provided, they represent successive allowable output
+lengths. If the highest provided `size` is less than `12`, then longer outputs
+will scale automatically, as above. If you do not want this auto-scaling
+behaviour, be sure to include `12` as the last value in the `size` array.
 
-Output lengths must be between 1 and 12. Other values will either be ignored
-or clamped to this range.
-
-Providing a minimum output length is generally recommended, because short
-sequences are easier to reverse-map and may leak information about your
-`Keymask` instance. For example, with no minimum defined, the first 40
-sequential integers (1...40) will all map to 1-character keymasks. Although
-these will be pseudo-randomized by the LCG and the shuffled encoding alphabet,
-the fact that they are all 1 character long may allow information about your
-seed to be deduced by anyone who is able to observe a series of values.
+Output lengths must be between `1` and `12`. Other values will be ignored.
 
 This setting should generally not be changed for the lifetime of your
-application, as this can interfere with the ability to unmask previously
-masked values.
+application, as this may interfere with the ability to unmask previously masked
+values.
 
-**Example**
+**Example (Defined output lengths)**
 
 ```JavaScript
 import { Keymask } from "keymask-base41";
 
 const keymask = new Keymask({
-  outputs: [6, 9]
+  size: [6, 9]
 });
 
-const masked = keymask.mask(12);
-const unmasked = keymask.unmask(masked);
-
-console.log(masked); // "pKJhNV"
-console.log(unmasked); // 12
+const masked = keymask.mask(12); // "pKJhNV"
+const unmasked = keymask.unmask(masked); // 12
 ```
 
 ### `bigint`
@@ -186,7 +182,7 @@ range (11- or 12-character encodings will be unmasked as a `bigint`). If you
 want *all* values to be returned as a `bigint`, regardless of their magnitude,
 then supply the option `bigint: true`.
 
-**Example**
+**Example (BigInt outputs)**
 
 ```JavaScript
 import { Keymask } from "keymask-base41";
@@ -195,27 +191,61 @@ const keymask = new Keymask({
   bigint: true
 });
 
-const masked = keymask.mask(123456789n);
-const unmasked = keymask.unmask(masked);
+const masked = keymask.mask(123456789n); // "wMjMGR"
+const unmasked = keymask.unmask(masked); // 123456789n
+```
 
-console.log(masked); // "wMjMGR"
-console.log(unmasked); // 123456789n
+### `encoder`
+
+It is not uncommon for an application to employ multiple serial numbers (for
+example, multiple database tables with auto-incrementing primary keys). In such
+cases, it may be desirable to have them each map to a unique keymask sequence.
+
+One option is to simply instantiate multiple `Keymask` instances, each with a
+unique 256-bit seed. A more efficient alternative is to have all of the
+instances share a single `Base41` encoder. The encoder can be seeded once
+(requires a 192-bit seed) and passed into each `Keymask` instance. As a result,
+each instance only requires an additional 64-bit seed to customize the LCG
+sequence.
+
+**Example (Multiple instances with a shared encoder)**
+
+```JavaScript
+import { Base41, Keymask } from "keymask-base41";
+
+const base41 = new Base41(new Uint8Array([
+  1, 2, 3, 4, 5, 6, 7, 8,
+  9, 10, 11, 12, 13, 14, 15, 16,
+  17, 18, 19, 20, 21, 22, 23, 24
+]));
+
+const keymask1 = new Keymask({
+  encoder: base41,
+  seed: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+  size: 5
+});
+
+const keymask2 = new Keymask({
+  encoder: base41,
+  seed: new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88]),
+  size: 5
+});
+
+const mask1a = keymask1.mask(1); // "bgLtm"
+const mask1b = keymask1.mask(2); // "FVyHP"
+const mask1c = keymask1.mask(3); // "vrMZL"
+const mask2a = keymask2.mask(1); // "LjjWh"
+const mask2b = keymask2.mask(2); // "RHRkJ"
+const mask2c = keymask2.mask(3); // "xmXrp"
 ```
 
 ## Performance
 
-Both the Linear Congruential Generator and the Base41 encoding are extremely
-simple operations, with execution times measured in microseconds or fractions
-of a microsecond. In most systems, there is very little chance that Keymask
-computations will form a significant bottleneck (provided you are processing
-less than ~1 million per second).
-
 On commodity hardware (2020 M1 Macbook Air), a single invocation of
-`Keymask.mask()` takes on the order of 20 microseconds (irrespective of output
-length), whereas a tight loop of one million invocations takes an average of
-between 0.2 and 0.7 microseconds per call (strongly dependent on the output
-length). As is often the case, performance characteristics differ substantially
-depending on whether or not the code is being executed by the JIT compiler.
+`Keymask.mask()` (JIT-compiled) takes on the order of 20 microseconds, whereas
+a tight loop of one million invocations takes an average of between 0.2 and 0.7
+microseconds per call, depending on the output length. This amounts to over a
+million keymasks per second.
 
 For best performance, the `Keymask` class instance should be cached for
 repeated usage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymask-base41",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Map sequential IDs or serial numbers to random-looking Base41-encoded strings",
   "type": "module",
   "exports": {

--- a/src/Base41.ts
+++ b/src/Base41.ts
@@ -113,17 +113,14 @@ export class Base41 {
         value = value.buffer;
       }
 
-      const values = new Uint8Array(value);
-      const blocks = new BigUint64Array(Math.ceil(values.length / 8));
-      const bytes = new Uint8Array(blocks.buffer);
-      bytes.set(values);
+      const blocks = new BigUint64Array(Math.ceil(value.byteLength / 8));
+      new Uint8Array(blocks.buffer).set(new Uint8Array(value));
 
-      let final: boolean;
+      const last = blocks.length - 1;
       blocks.forEach((block, index) => {
-        final = index === blocks.length - 1;
         result += this.encodeValue(
           block,
-          final ? length : 12,
+          index === last ? length : 12,
         );
       });
 

--- a/src/Keymask.ts
+++ b/src/Keymask.ts
@@ -1,18 +1,56 @@
-import { Base41 } from "./index";
-import { Generator } from "./index";
+import { Base41, Generator } from "./index";
 
-export interface KeymaskOptions {
-  seed?: ArrayBufferLike | ArrayBufferView;
-  outputs?: number | number[];
-  bigint?: boolean;
+const limits: bigint[] = [
+  0n,
+  41n,
+  1021n,
+  65521n,
+  2097143n,
+  67108859n,
+  4294967291n,
+  137438953447n,
+  4398046511093n,
+  281474976710597n,
+  9007199254740881n,
+  288230376151711717n,
+  18446744073709551557n
+];
+
+function encodingLength(value: number | bigint, sizes: number[]): number {
+  let length = 12;
+  let size = 0;
+  value = typeof value === "bigint" ? value : BigInt(value);
+  for (let i = 0; i < sizes.length; i++) {
+    size = sizes[i];
+    if (value < limits[size]) {
+      length = size;
+      break;
+    }
+  }
+  if (length === 12 && value >= limits[size]) {
+    for (let i = sizes[sizes.length - 1] + 1; i < 12; i++) {
+      if (value < limits[i]) {
+        length = i;
+        break;
+      }
+    }
+  }
+  return length;
 }
+
+export type KeymaskOptions = {
+  seed?: ArrayBufferLike | ArrayBufferView;
+  size?: number | number[];
+  bigint?: boolean;
+};
 
 export class Keymask {
   private base41: Base41;
   private generator: Generator;
+  private sizes: number[];
 
   constructor(options?: KeymaskOptions) {
-    options = options || {};
+    options = options || {} as KeymaskOptions;
 
     let seed = options.seed;
     if (seed && seed.byteLength > 7) {
@@ -20,7 +58,7 @@ export class Keymask {
         seed = seed.buffer;
       }
       if (seed.byteLength < 24) {
-        this.generator = new Generator(seed.slice(0, 8), options.bigint);
+        this.generator = new Generator(seed, options.bigint);
         delete options.seed;
 
       } else if (seed.byteLength < 32) {
@@ -28,7 +66,7 @@ export class Keymask {
         options.seed = seed.slice(0, 24);
 
       } else {
-        this.generator = new Generator(seed.slice(0, 8), options.bigint);
+        this.generator = new Generator(seed, options.bigint);
         options.seed = seed.slice(8, 32);
       }
     } else {
@@ -37,11 +75,18 @@ export class Keymask {
         delete options.seed;
       }
     }
-    this.base41 = new Base41(options);
+    this.base41 = new Base41(options.seed);
+
+    const sizes = options.size;
+    if (Array.isArray(sizes)) {
+      this.sizes = sizes.filter((size) => size > 0 && size < 13).sort((a, b) => a - b);
+    } else {
+      this.sizes = [sizes && sizes > 0 && sizes < 13 ? sizes : 1];
+    }
   }
 
   mask(value: number | bigint): string {
-    const length = this.base41.encodingLength(value);
+    const length = encodingLength(value, this.sizes);
     const n = this.generator.next(value, length);
     return this.base41.encode(n, length);
   }

--- a/src/Keymask.ts
+++ b/src/Keymask.ts
@@ -37,7 +37,7 @@ export class Keymask {
         delete options.seed;
       }
     }
-    this.base41 = new Base41({ ...options, prime: true, pad: true });
+    this.base41 = new Base41(options);
   }
 
   mask(value: number | bigint): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Base41, type Base41Options } from "./Base41";
+export { Base41 } from "./Base41";
 export { Generator } from "./Generator";
 export { Keymask, type KeymaskOptions } from "./Keymask";

--- a/test/Base41.test.ts
+++ b/test/Base41.test.ts
@@ -24,741 +24,408 @@ describe("Base41", () => {
   });
 
   describe("Unseeded", () => {
-    describe("Non-prime", () => {
-      describe("Adaptive", () => {
-        describe("Padded", () => {
-          const base41 = new Base41();
+    describe("Adaptive", () => {
+      const base41 = new Base41();
 
-          describe("Single value", () => {
-            it("should handle null character encodings", () => {
-              equal(base41.encode(0), "B");
-              equal(base41.decode("B"), 0);
-            });
-
-            it("should handle 1-character encodings", () => {
-              equal(base41.encode(1), "C");
-              equal(base41.encode(31), "p");
-              equal(base41.decode("C"), 1);
-              equal(base41.decode("p"), 31);
-            });
-
-            it("should handle 2-character encodings", () => {
-              equal(base41.encode(32), "qB");
-              equal(base41.encode(1023), "yf");
-              equal(base41.decode("qB"), 32);
-              equal(base41.decode("yf"), 1023);
-            });
-
-            it("should handle 3-character encodings", () => {
-              equal(base41.encode(1024), "zfB");
-              equal(base41.encode(65535), "Wzx");
-              equal(base41.decode("zfB"), 1024);
-              equal(base41.decode("Wzx"), 65535);
-            });
-
-            it("should handle 4-character encodings", () => {
-              equal(base41.encode(65536), "XzxB");
-              equal(base41.encode(2097151), "CdWn");
-              equal(base41.decode("XzxB"), 65536);
-              equal(base41.decode("CdWn"), 2097151);
-            });
-
-            it("should handle 5-character encodings", () => {
-              equal(base41.encode(2097152), "DdWnB");
-              equal(base41.encode(67108863), "czknd");
-              equal(base41.decode("DdWnB"), 2097152);
-              equal(base41.decode("czknd"), 67108863);
-            });
-
-            it("should handle 6-character encodings", () => {
-              equal(base41.encode(67108864), "dzkndB");
-              equal(base41.encode(4294967295), "vQNxDw");
-              equal(base41.decode("dzkndB"), 67108864);
-              equal(base41.decode("vQNxDw"), 4294967295);
-            });
-
-            it("should handle 7-character encodings", () => {
-              equal(base41.encode(4294967296), "wQNxDwB");
-              equal(base41.encode(137438953471), "tDDtPxk");
-              equal(base41.decode("wQNxDwB"), 4294967296);
-              equal(base41.decode("tDDtPxk"), 137438953471);
-            });
-
-            it("should handle 8-character encodings", () => {
-              equal(base41.encode(137438953472), "vDDtPxkB");
-              equal(base41.encode(4398046511103), "FNgSNvdc");
-              equal(base41.decode("vDDtPxkB"), 137438953472);
-              equal(base41.decode("FNgSNvdc"), 4398046511103);
-            });
-
-            it("should handle 9-character encodings", () => {
-              equal(base41.encode(4398046511104), "GNgSNvdcB");
-              equal(base41.encode(281474976710655), "MpVrJfPNt");
-              equal(base41.decode("GNgSNvdcB"), 4398046511104);
-              equal(base41.decode("MpVrJfPNt"), 281474976710655);
-            });
-
-            it("should handle 10-character encodings", () => {
-              equal(base41.encode(281474976710656), "NpVrJfPNtB");
-              equal(base41.encode(9007199254740991), "qTFFRtCCbj");
-              equal(base41.decode("NpVrJfPNtB"), 281474976710656);
-              equal(base41.decode("qTFFRtCCbj"), 9007199254740991);
-            });
-
-            it("should handle 11-character encodings", () => {
-              equal(base41.encode(9007199254740992n), "rTFFRtCCbjB");
-              equal(base41.encode(288230376151711739n), "hRhVLdXrVYb");
-              equal(base41.decode("rTFFRtCCbjB"), 9007199254740992n);
-              equal(base41.decode("hRhVLdXrVYb"), 288230376151711739n);
-            });
-
-            it("should handle 12-character encodings", () => {
-              equal(base41.encode(288230376151711740n), "jRhVLdXrVYbB");
-              equal(base41.encode(18446744073709551615n), "TYGzGMzLNQbr");
-              equal(base41.decode("jRhVLdXrVYbB"), 288230376151711740n);
-              equal(base41.decode("TYGzGMzLNQbr"), 18446744073709551615n);
-            });
-          });
-
-          describe("Multiple values", () => {
-            it("should handle 1-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBC");
-              equal(base41.encode(new BigUint64Array([31n, 31n])), "pBBBBBBBBBBBp");
-              deepEqual(base41.decode("CBBBBBBBBBBBC"), new BigUint64Array([1n, 1n]).buffer);
-              deepEqual(base41.decode("pBBBBBBBBBBBp"), new BigUint64Array([31n, 31n]).buffer);
-            });
-
-            it("should handle 2-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([32n, 32n])), "qBBBBBBBBBBBqB");
-              equal(base41.encode(new BigUint64Array([1023n, 1023n])), "yfBBBBBBBBBByf");
-              deepEqual(base41.decode("qBBBBBBBBBBBqB"), new BigUint64Array([32n, 32n]).buffer);
-              deepEqual(base41.decode("yfBBBBBBBBBByf"), new BigUint64Array([1023n, 1023n]).buffer);
-            });
-
-            it("should handle 3-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([1024n, 1024n])), "zfBBBBBBBBBBzfB");
-              equal(base41.encode(new BigUint64Array([65535n, 65535n])), "WzxBBBBBBBBBWzx");
-              deepEqual(base41.decode("zfBBBBBBBBBBzfB"), new BigUint64Array([1024n, 1024n]).buffer);
-              deepEqual(base41.decode("WzxBBBBBBBBBWzx"), new BigUint64Array([65535n, 65535n]).buffer);
-            });
-
-            it("should handle 10-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([281474976710656n, 281474976710656n])), "NpVrJfPNtBBBNpVrJfPNtB");
-              equal(base41.encode(new BigUint64Array([9007199254740991n, 9007199254740991n])), "qTFFRtCCbjBBqTFFRtCCbj");
-              deepEqual(base41.decode("NpVrJfPNtBBBNpVrJfPNtB"), new BigUint64Array([281474976710656n, 281474976710656n]).buffer);
-              deepEqual(base41.decode("qTFFRtCCbjBBqTFFRtCCbj"), new BigUint64Array([9007199254740991n, 9007199254740991n]).buffer);
-            });
-
-            it("should handle 11-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([9007199254740992n, 9007199254740992n])), "rTFFRtCCbjBBrTFFRtCCbjB");
-              equal(base41.encode(new BigUint64Array([288230376151711739n, 288230376151711739n])), "hRhVLdXrVYbBhRhVLdXrVYb");
-              deepEqual(base41.decode("rTFFRtCCbjBBrTFFRtCCbjB"), new BigUint64Array([9007199254740992n, 9007199254740992n]).buffer);
-              deepEqual(base41.decode("hRhVLdXrVYbBhRhVLdXrVYb"), new BigUint64Array([288230376151711739n, 288230376151711739n]).buffer);
-            });
-
-            it("should handle 12-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([288230376151711740n, 288230376151711740n])), "jRhVLdXrVYbBjRhVLdXrVYbB");
-              equal(base41.encode(new BigUint64Array([18446744073709551615n, 18446744073709551615n])), "TYGzGMzLNQbrTYGzGMzLNQbr");
-              deepEqual(base41.decode("jRhVLdXrVYbBjRhVLdXrVYbB"), new BigUint64Array([288230376151711740n, 288230376151711740n]).buffer);
-              deepEqual(base41.decode("TYGzGMzLNQbrTYGzGMzLNQbr"), new BigUint64Array([18446744073709551615n, 18446744073709551615n]).buffer);
-            });
-          });
+      describe("Single value", () => {
+        it("should handle 1-character encodings", () => {
+          equal(base41.encode(1), "C");
+          equal(base41.encode(40), "z");
+          equal(base41.decode("C"), 1);
+          equal(base41.decode("z"), 40);
         });
 
-        describe("Unpadded", () => {
-          const base41 = new Base41({
-            pad: false
-          });
+        it("should handle 2-character encodings", () => {
+          equal(base41.encode(41), "BC");
+          equal(base41.encode(1020), "vf");
+          equal(base41.decode("BC"), 41);
+          equal(base41.decode("vf"), 1020);
+        });
 
-          it("should handle 1-character encodings", () => {
-            equal(base41.encode(1), "C");
-            equal(base41.encode(31), "p");
-            equal(base41.decode("C"), 1);
-            equal(base41.decode("p"), 31);
-          });
+        it("should handle 3-character encodings", () => {
+          equal(base41.encode(1021), "wfB");
+          equal(base41.encode(65520), "Dzx");
+          equal(base41.decode("wfB"), 1021);
+          equal(base41.decode("Dzx"), 65520);
+        });
 
-          it("should handle 2-character encodings", () => {
-            equal(base41.encode(32), "q");
-            equal(base41.encode(1023), "yf");
-            equal(base41.decode("q"), 32);
-            equal(base41.decode("yf"), 1023);
-          });
+        it("should handle 4-character encodings", () => {
+          equal(base41.encode(65521), "FzxB");
+          equal(base41.encode(2097142), "rcWn");
+          equal(base41.decode("FzxB"), 65521);
+          equal(base41.decode("rcWn"), 2097142);
+        });
 
-          it("should handle 3-character encodings", () => {
-            equal(base41.encode(1024), "zf");
-            equal(base41.encode(65535), "Wzx");
-            equal(base41.decode("zf"), 1024);
-            equal(base41.decode("Wzx"), 65535);
-          });
+        it("should handle 5-character encodings", () => {
+          equal(base41.encode(2097143), "scWnB");
+          equal(base41.encode(67108858), "Wzknd");
+          equal(base41.decode("scWnB"), 2097143);
+          equal(base41.decode("Wzknd"), 67108858);
+        });
 
-          it("should handle 4-character encodings", () => {
-            equal(base41.encode(65536), "Xzx");
-            equal(base41.encode(2097151), "CdWn");
-            equal(base41.decode("Xzx"), 65536);
-            equal(base41.decode("CdWn"), 2097151);
-          });
+        it("should handle 6-character encodings", () => {
+          equal(base41.encode(67108859), "XzkndB");
+          equal(base41.encode(4294967290), "pQNxDw");
+          equal(base41.decode("XzkndB"), 67108859);
+          equal(base41.decode("pQNxDw"), 4294967290);
+        });
 
-          it("should handle 5-character encodings", () => {
-            equal(base41.encode(2097152), "DdWn");
-            equal(base41.encode(67108863), "czknd");
-            equal(base41.decode("DdWn"), 2097152);
-            equal(base41.decode("czknd"), 67108863);
-          });
+        it("should handle 7-character encodings", () => {
+          equal(base41.encode(4294967291), "qQNxDwB");
+          equal(base41.encode(137438953446), "NDDtPxk");
+          equal(base41.decode("qQNxDwB"), 4294967291);
+          equal(base41.decode("NDDtPxk"), 137438953446);
+        });
 
-          it("should handle 6-character encodings", () => {
-            equal(base41.encode(67108864), "dzknd");
-            equal(base41.encode(4294967295), "vQNxDw");
-            equal(base41.decode("dzknd"), 67108864);
-            equal(base41.decode("vQNxDw"), 4294967295);
-          });
+        it("should handle 8-character encodings", () => {
+          equal(base41.encode(137438953447), "PDDtPxkB");
+          equal(base41.encode(4398046511092), "rMgSNvdc");
+          equal(base41.decode("PDDtPxkB"), 137438953447);
+          equal(base41.decode("rMgSNvdc"), 4398046511092);
+        });
 
-          it("should handle 7-character encodings", () => {
-            equal(base41.encode(4294967296), "wQNxDw");
-            equal(base41.encode(137438953471), "tDDtPxk");
-            equal(base41.decode("wQNxDw"), 4294967296);
-            equal(base41.decode("tDDtPxk"), 137438953471);
-          });
+        it("should handle 9-character encodings", () => {
+          equal(base41.encode(4398046511093), "sMgSNvdcB");
+          equal(base41.encode(281474976710596), "qmVrJfPNt");
+          equal(base41.decode("sMgSNvdcB"), 4398046511093);
+          equal(base41.decode("qmVrJfPNt"), 281474976710596);
+        });
 
-          it("should handle 8-character encodings", () => {
-            equal(base41.encode(137438953472), "vDDtPxk");
-            equal(base41.encode(4398046511103), "FNgSNvdc");
-            equal(base41.decode("vDDtPxk"), 137438953472);
-            equal(base41.decode("FNgSNvdc"), 4398046511103);
-          });
+        it("should handle 10-character encodings", () => {
+          equal(base41.encode(281474976710597), "rmVrJfPNtB");
+          equal(base41.encode(9007199254740880), "FRFFRtCCbj");
+          equal(base41.decode("rmVrJfPNtB"), 281474976710597);
+          equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
+        });
 
-          it("should handle 9-character encodings", () => {
-            equal(base41.encode(4398046511104), "GNgSNvdc");
-            equal(base41.encode(281474976710655), "MpVrJfPNt");
-            equal(base41.decode("GNgSNvdc"), 4398046511104);
-            equal(base41.decode("MpVrJfPNt"), 281474976710655);
-          });
+        it("should handle 11-character encodings", () => {
+          equal(base41.encode(9007199254740881), "GRFFRtCCbjB");
+          equal(base41.encode(288230376151711716n), "FRhVLdXrVYb");
+          equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
+          equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
+        });
 
-          it("should handle 10-character encodings", () => {
-            equal(base41.encode(281474976710656), "NpVrJfPNt");
-            equal(base41.encode(9007199254740991), "qTFFRtCCbj");
-            equal(base41.decode("NpVrJfPNt"), 281474976710656);
-            equal(base41.decode("qTFFRtCCbj"), 9007199254740991);
-          });
-
-          it("should handle 11-character encodings", () => {
-            equal(base41.encode(9007199254740992), "rTFFRtCCbj");
-            equal(base41.encode(288230376151711739n), "hRhVLdXrVYb");
-            equal(base41.decode("rTFFRtCCbj"), 9007199254740992);
-            equal(base41.decode("hRhVLdXrVYb"), 288230376151711739n);
-          });
-
-          it("should handle 12-character encodings", () => {
-            equal(base41.encode(288230376151711740n), "jRhVLdXrVYb");
-            equal(base41.encode(18446744073709551615n), "TYGzGMzLNQbr");
-            equal(base41.decode("jRhVLdXrVYb"), 288230376151711740n);
-            equal(base41.decode("TYGzGMzLNQbr"), 18446744073709551615n);
-          });
+        it("should handle 12-character encodings", () => {
+          equal(base41.encode(288230376151711717n), "GRhVLdXrVYbB");
+          equal(base41.encode(18446744073709551556n), "xWGzGMzLNQbr");
+          equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
+          equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
         });
       });
 
-      describe("Fluid (single output length)", () => {
-        describe("Padded", () => {
-          const base41 = new Base41({
-            outputs: 7
-          });
-
-          it("should handle 1-character encodings", () => {
-            equal(base41.encode(1), "CBBBBBB");
-            equal(base41.encode(31), "pBBBBBB");
-            equal(base41.decode("CBBBBBB"), 1);
-            equal(base41.decode("pBBBBBB"), 31);
-          });
-
-          it("should handle 2-character encodings", () => {
-            equal(base41.encode(32), "qBBBBBB");
-            equal(base41.encode(1023), "yfBBBBB");
-            equal(base41.decode("qBBBBBB"), 32);
-            equal(base41.decode("yfBBBBB"), 1023);
-          });
-
-          it("should handle 3-character encodings", () => {
-            equal(base41.encode(1024), "zfBBBBB");
-            equal(base41.encode(65535), "WzxBBBB");
-            equal(base41.decode("zfBBBBB"), 1024);
-            equal(base41.decode("WzxBBBB"), 65535);
-          });
-
-          it("should handle 4-character encodings", () => {
-            equal(base41.encode(65536), "XzxBBBB");
-            equal(base41.encode(2097151), "CdWnBBB");
-            equal(base41.decode("XzxBBBB"), 65536);
-            equal(base41.decode("CdWnBBB"), 2097151);
-          });
-
-          it("should handle 5-character encodings", () => {
-            equal(base41.encode(2097152), "DdWnBBB");
-            equal(base41.encode(67108863), "czkndBB");
-            equal(base41.decode("DdWnBBB"), 2097152);
-            equal(base41.decode("czkndBB"), 67108863);
-          });
-
-          it("should handle 6-character encodings", () => {
-            equal(base41.encode(67108864), "dzkndBB");
-            equal(base41.encode(4294967295), "vQNxDwB");
-            equal(base41.decode("dzkndBB"), 67108864);
-            equal(base41.decode("vQNxDwB"), 4294967295);
-          });
-
-          it("should handle 7-character encodings", () => {
-            equal(base41.encode(4294967296), "wQNxDwB");
-            equal(base41.encode(137438953471), "tDDtPxk");
-            equal(base41.decode("wQNxDwB"), 4294967296);
-            equal(base41.decode("tDDtPxk"), 137438953471);
-          });
-
-          it("should handle 8-character encodings", () => {
-            equal(base41.encode(137438953472), "vDDtPxkB");
-            equal(base41.encode(4398046511103), "FNgSNvdc");
-            equal(base41.decode("vDDtPxkB"), 137438953472);
-            equal(base41.decode("FNgSNvdc"), 4398046511103);
-          });
-
-          it("should handle 9-character encodings", () => {
-            equal(base41.encode(4398046511104), "GNgSNvdcB");
-            equal(base41.encode(281474976710655), "MpVrJfPNt");
-            equal(base41.decode("GNgSNvdcB"), 4398046511104);
-            equal(base41.decode("MpVrJfPNt"), 281474976710655);
-          });
-
-          it("should handle 10-character encodings", () => {
-            equal(base41.encode(281474976710656), "NpVrJfPNtB");
-            equal(base41.encode(9007199254740991), "qTFFRtCCbj");
-            equal(base41.decode("NpVrJfPNtB"), 281474976710656);
-            equal(base41.decode("qTFFRtCCbj"), 9007199254740991);
-          });
-
-          it("should handle 11-character encodings", () => {
-            equal(base41.encode(9007199254740992n), "rTFFRtCCbjB");
-            equal(base41.encode(288230376151711739n), "hRhVLdXrVYb");
-            equal(base41.decode("rTFFRtCCbjB"), 9007199254740992n);
-            equal(base41.decode("hRhVLdXrVYb"), 288230376151711739n);
-          });
-
-          it("should handle 12-character encodings", () => {
-            equal(base41.encode(288230376151711740n), "jRhVLdXrVYbB");
-            equal(base41.encode(18446744073709551615n), "TYGzGMzLNQbr");
-            equal(base41.decode("jRhVLdXrVYbB"), 288230376151711740n);
-            equal(base41.decode("TYGzGMzLNQbr"), 18446744073709551615n);
-          });
+      describe("Multiple values", () => {
+        it("should handle 1-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBC");
+          equal(base41.encode(new BigUint64Array([40n, 40n])), "zBBBBBBBBBBBz");
+          deepEqual(base41.decode("CBBBBBBBBBBBC"), new BigUint64Array([1n, 1n]).buffer);
+          deepEqual(base41.decode("zBBBBBBBBBBBz"), new BigUint64Array([40n, 40n]).buffer);
         });
 
-        describe("Unpadded", () => {
-          const base41 = new Base41({
-            outputs: 7,
-            pad: false
-          });
-
-          it("should handle 1-character encodings", () => {
-            equal(base41.encode(1), "CBBBBBB");
-            equal(base41.encode(31), "pBBBBBB");
-            equal(base41.decode("CBBBBBB"), 1);
-            equal(base41.decode("pBBBBBB"), 31);
-          });
-
-          it("should handle 2-character encodings", () => {
-            equal(base41.encode(32), "qBBBBBB");
-            equal(base41.encode(1023), "yfBBBBB");
-            equal(base41.decode("qBBBBBB"), 32);
-            equal(base41.decode("yfBBBBB"), 1023);
-          });
-
-          it("should handle 3-character encodings", () => {
-            equal(base41.encode(1024), "zfBBBBB");
-            equal(base41.encode(65535), "WzxBBBB");
-            equal(base41.decode("zfBBBBB"), 1024);
-            equal(base41.decode("WzxBBBB"), 65535);
-          });
-
-          it("should handle 4-character encodings", () => {
-            equal(base41.encode(65536), "XzxBBBB");
-            equal(base41.encode(2097151), "CdWnBBB");
-            equal(base41.decode("XzxBBBB"), 65536);
-            equal(base41.decode("CdWnBBB"), 2097151);
-          });
-
-          it("should handle 5-character encodings", () => {
-            equal(base41.encode(2097152), "DdWnBBB");
-            equal(base41.encode(67108863), "czkndBB");
-            equal(base41.decode("DdWnBBB"), 2097152);
-            equal(base41.decode("czkndBB"), 67108863);
-          });
-
-          it("should handle 6-character encodings", () => {
-            equal(base41.encode(67108864), "dzkndBB");
-            equal(base41.encode(4294967295), "vQNxDwB");
-            equal(base41.decode("dzkndBB"), 67108864);
-            equal(base41.decode("vQNxDwB"), 4294967295);
-          });
-
-          it("should handle 7-character encodings", () => {
-            equal(base41.encode(4294967296), "wQNxDwB");
-            equal(base41.encode(137438953471), "tDDtPxk");
-            equal(base41.decode("wQNxDwB"), 4294967296);
-            equal(base41.decode("tDDtPxk"), 137438953471);
-          });
-
-          it("should handle 8-character encodings", () => {
-            equal(base41.encode(137438953472), "vDDtPxk");
-            equal(base41.encode(4398046511103), "FNgSNvdc");
-            equal(base41.decode("vDDtPxk"), 137438953472);
-            equal(base41.decode("FNgSNvdc"), 4398046511103);
-          });
-
-          it("should handle 9-character encodings", () => {
-            equal(base41.encode(4398046511104), "GNgSNvdc");
-            equal(base41.encode(281474976710655), "MpVrJfPNt");
-            equal(base41.decode("GNgSNvdc"), 4398046511104);
-            equal(base41.decode("MpVrJfPNt"), 281474976710655);
-          });
-
-          it("should handle 10-character encodings", () => {
-            equal(base41.encode(281474976710656), "NpVrJfPNt");
-            equal(base41.encode(9007199254740991), "qTFFRtCCbj");
-            equal(base41.decode("NpVrJfPNt"), 281474976710656);
-            equal(base41.decode("qTFFRtCCbj"), 9007199254740991);
-          });
-
-          it("should handle 11-character encodings", () => {
-            equal(base41.encode(9007199254740992), "rTFFRtCCbj");
-            equal(base41.encode(288230376151711739n), "hRhVLdXrVYb");
-            equal(base41.decode("rTFFRtCCbj"), 9007199254740992);
-            equal(base41.decode("hRhVLdXrVYb"), 288230376151711739n);
-          });
-
-          it("should handle 12-character encodings", () => {
-            equal(base41.encode(288230376151711740n), "jRhVLdXrVYb");
-            equal(base41.encode(18446744073709551615n), "TYGzGMzLNQbr");
-            equal(base41.decode("jRhVLdXrVYb"), 288230376151711740n);
-            equal(base41.decode("TYGzGMzLNQbr"), 18446744073709551615n);
-          });
-        });
-      });
-
-      describe("Explicit (multiple output lengths)", () => {
-        describe("Padded", () => {
-          const base41 = new Base41({
-            outputs: [5, 7]
-          });
-
-          it("should handle 1-character encodings", () => {
-            equal(base41.encode(1), "CBBBB");
-            equal(base41.encode(31), "pBBBB");
-            equal(base41.decode("CBBBB"), 1);
-            equal(base41.decode("pBBBB"), 31);
-          });
-
-          it("should handle 2-character encodings", () => {
-            equal(base41.encode(32), "qBBBB");
-            equal(base41.encode(1023), "yfBBB");
-            equal(base41.decode("qBBBB"), 32);
-            equal(base41.decode("yfBBB"), 1023);
-          });
-
-          it("should handle 3-character encodings", () => {
-            equal(base41.encode(1024), "zfBBB");
-            equal(base41.encode(65535), "WzxBB");
-            equal(base41.decode("zfBBB"), 1024);
-            equal(base41.decode("WzxBB"), 65535);
-          });
-
-          it("should handle 4-character encodings", () => {
-            equal(base41.encode(65536), "XzxBB");
-            equal(base41.encode(2097151), "CdWnB");
-            equal(base41.decode("XzxBB"), 65536);
-            equal(base41.decode("CdWnB"), 2097151);
-          });
-
-          it("should handle 5-character encodings", () => {
-            equal(base41.encode(2097152), "DdWnB");
-            equal(base41.encode(67108863), "czknd");
-            equal(base41.decode("DdWnB"), 2097152);
-            equal(base41.decode("czknd"), 67108863);
-          });
-
-          it("should handle 6-character encodings", () => {
-            equal(base41.encode(67108864), "dzkndBB");
-            equal(base41.encode(4294967295), "vQNxDwB");
-            equal(base41.decode("dzkndBB"), 67108864);
-            equal(base41.decode("vQNxDwB"), 4294967295);
-          });
-
-          it("should handle 7-character encodings", () => {
-            equal(base41.encode(4294967296), "wQNxDwB");
-            equal(base41.encode(137438953471), "tDDtPxk");
-            equal(base41.decode("wQNxDwB"), 4294967296);
-            equal(base41.decode("tDDtPxk"), 137438953471);
-          });
-
-          it("should handle 8-character encodings", () => {
-            equal(base41.encode(137438953472), "vDDtPxkB");
-            equal(base41.encode(4398046511103), "FNgSNvdc");
-            equal(base41.decode("vDDtPxkB"), 137438953472);
-            equal(base41.decode("FNgSNvdc"), 4398046511103);
-          });
-
-          it("should handle 9-character encodings", () => {
-            equal(base41.encode(4398046511104), "GNgSNvdcB");
-            equal(base41.encode(281474976710655), "MpVrJfPNt");
-            equal(base41.decode("GNgSNvdcB"), 4398046511104);
-            equal(base41.decode("MpVrJfPNt"), 281474976710655);
-          });
-
-          it("should handle 10-character encodings", () => {
-            equal(base41.encode(281474976710656), "NpVrJfPNtB");
-            equal(base41.encode(9007199254740991), "qTFFRtCCbj");
-            equal(base41.decode("NpVrJfPNtB"), 281474976710656);
-            equal(base41.decode("qTFFRtCCbj"), 9007199254740991);
-          });
-
-          it("should handle 11-character encodings", () => {
-            equal(base41.encode(9007199254740992n), "rTFFRtCCbjB");
-            equal(base41.encode(288230376151711739n), "hRhVLdXrVYb");
-            equal(base41.decode("rTFFRtCCbjB"), 9007199254740992n);
-            equal(base41.decode("hRhVLdXrVYb"), 288230376151711739n);
-          });
-
-          it("should handle 12-character encodings", () => {
-            equal(base41.encode(288230376151711740n), "jRhVLdXrVYbB");
-            equal(base41.encode(18446744073709551615n), "TYGzGMzLNQbr");
-            equal(base41.decode("jRhVLdXrVYbB"), 288230376151711740n);
-            equal(base41.decode("TYGzGMzLNQbr"), 18446744073709551615n);
-          });
+        it("should handle 2-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([41n, 41n])), "BCBBBBBBBBBBBC");
+          equal(base41.encode(new BigUint64Array([1020n, 1020n])), "vfBBBBBBBBBBvf");
+          deepEqual(base41.decode("BCBBBBBBBBBBBC"), new BigUint64Array([41n, 41n]).buffer);
+          deepEqual(base41.decode("vfBBBBBBBBBBvf"), new BigUint64Array([1020n, 1020n]).buffer);
         });
 
-        describe("Unpadded", () => {
-          const base41 = new Base41({
-            outputs: [5, 7],
-            pad: false
-          });
+        it("should handle 3-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([1021n, 1021n])), "wfBBBBBBBBBBwfB");
+          equal(base41.encode(new BigUint64Array([65520n, 65520n])), "DzxBBBBBBBBBDzx");
+          deepEqual(base41.decode("wfBBBBBBBBBBwfB"), new BigUint64Array([1021n, 1021n]).buffer);
+          deepEqual(base41.decode("DzxBBBBBBBBBDzx"), new BigUint64Array([65520n, 65520n]).buffer);
+        });
 
-          it("should handle 1-character encodings", () => {
-            equal(base41.encode(1), "CBBBB");
-            equal(base41.encode(31), "pBBBB");
-            equal(base41.decode("CBBBB"), 1);
-            equal(base41.decode("pBBBB"), 31);
-          });
+        it("should handle 10-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n])), "rmVrJfPNtBBBrmVrJfPNtB");
+          equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n])), "FRFFRtCCbjBBFRFFRtCCbj");
+          deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
+          deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
+        });
 
-          it("should handle 2-character encodings", () => {
-            equal(base41.encode(32), "qBBBB");
-            equal(base41.encode(1023), "yfBBB");
-            equal(base41.decode("qBBBB"), 32);
-            equal(base41.decode("yfBBB"), 1023);
-          });
+        it("should handle 11-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n])), "GRFFRtCCbjBBGRFFRtCCbjB");
+          equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n])), "FRhVLdXrVYbBFRhVLdXrVYb");
+          deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
+          deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
+        });
 
-          it("should handle 3-character encodings", () => {
-            equal(base41.encode(1024), "zfBBB");
-            equal(base41.encode(65535), "WzxBB");
-            equal(base41.decode("zfBBB"), 1024);
-            equal(base41.decode("WzxBB"), 65535);
-          });
-
-          it("should handle 4-character encodings", () => {
-            equal(base41.encode(65536), "XzxBB");
-            equal(base41.encode(2097151), "CdWnB");
-            equal(base41.decode("XzxBB"), 65536);
-            equal(base41.decode("CdWnB"), 2097151);
-          });
-
-          it("should handle 5-character encodings", () => {
-            equal(base41.encode(2097152), "DdWnB");
-            equal(base41.encode(67108863), "czknd");
-            equal(base41.decode("DdWnB"), 2097152);
-            equal(base41.decode("czknd"), 67108863);
-          });
-
-          it("should handle 6-character encodings", () => {
-            equal(base41.encode(67108864), "dzkndBB");
-            equal(base41.encode(4294967295), "vQNxDwB");
-            equal(base41.decode("dzkndBB"), 67108864);
-            equal(base41.decode("vQNxDwB"), 4294967295);
-          });
-
-          it("should handle 7-character encodings", () => {
-            equal(base41.encode(4294967296), "wQNxDwB");
-            equal(base41.encode(137438953471), "tDDtPxk");
-            equal(base41.decode("wQNxDwB"), 4294967296);
-            equal(base41.decode("tDDtPxk"), 137438953471);
-          });
-
-          it("should handle 8-character encodings", () => {
-            equal(base41.encode(137438953472), "vDDtPxk");
-            equal(base41.encode(4398046511103), "FNgSNvdc");
-            equal(base41.decode("vDDtPxk"), 137438953472);
-            equal(base41.decode("FNgSNvdc"), 4398046511103);
-          });
-
-          it("should handle 9-character encodings", () => {
-            equal(base41.encode(4398046511104), "GNgSNvdc");
-            equal(base41.encode(281474976710655), "MpVrJfPNt");
-            equal(base41.decode("GNgSNvdc"), 4398046511104);
-            equal(base41.decode("MpVrJfPNt"), 281474976710655);
-          });
-
-          it("should handle 10-character encodings", () => {
-            equal(base41.encode(281474976710656), "NpVrJfPNt");
-            equal(base41.encode(9007199254740991), "qTFFRtCCbj");
-            equal(base41.decode("NpVrJfPNt"), 281474976710656);
-            equal(base41.decode("qTFFRtCCbj"), 9007199254740991);
-          });
-
-          it("should handle 11-character encodings", () => {
-            equal(base41.encode(9007199254740992), "rTFFRtCCbj");
-            equal(base41.encode(288230376151711739n), "hRhVLdXrVYb");
-            equal(base41.decode("rTFFRtCCbj"), 9007199254740992);
-            equal(base41.decode("hRhVLdXrVYb"), 288230376151711739n);
-          });
-
-          it("should handle 12-character encodings", () => {
-            equal(base41.encode(288230376151711740n), "jRhVLdXrVYb");
-            equal(base41.encode(18446744073709551615n), "TYGzGMzLNQbr");
-            equal(base41.decode("jRhVLdXrVYb"), 288230376151711740n);
-            equal(base41.decode("TYGzGMzLNQbr"), 18446744073709551615n);
-          });
+        it("should handle 12-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n])), "GRhVLdXrVYbBGRhVLdXrVYbB");
+          equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n])), "xWGzGMzLNQbrxWGzGMzLNQbr");
+          deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
+          deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
         });
       });
     });
 
-    describe("Prime", () => {
-      describe("Adaptive", () => {
-        describe("Padded", () => {
-          const base41 = new Base41({
-            prime: true
-          });
+    describe("Fluid (single output length)", () => {
+      const base41 = new Base41({
+        outputs: 7
+      });
 
-          describe("Single value", () => {
-            it("should handle 1-character encodings", () => {
-              equal(base41.encode(1), "C");
-              equal(base41.encode(40), "z");
-              equal(base41.decode("C"), 1);
-              equal(base41.decode("z"), 40);
-            });
+      describe("Single value", () => {
+        it("should handle 1-character encodings", () => {
+          equal(base41.encode(1), "CBBBBBB");
+          equal(base41.encode(40), "zBBBBBB");
+          equal(base41.decode("CBBBBBB"), 1);
+          equal(base41.decode("zBBBBBB"), 40);
+        });
 
-            it("should handle 2-character encodings", () => {
-              equal(base41.encode(41), "BC");
-              equal(base41.encode(1020), "vf");
-              equal(base41.decode("BC"), 41);
-              equal(base41.decode("vf"), 1020);
-            });
+        it("should handle 2-character encodings", () => {
+          equal(base41.encode(41), "BCBBBBB");
+          equal(base41.encode(1020), "vfBBBBB");
+          equal(base41.decode("BCBBBBB"), 41);
+          equal(base41.decode("vfBBBBB"), 1020);
+        });
 
-            it("should handle 3-character encodings", () => {
-              equal(base41.encode(1021), "wfB");
-              equal(base41.encode(65520), "Dzx");
-              equal(base41.decode("wfB"), 1021);
-              equal(base41.decode("Dzx"), 65520);
-            });
+        it("should handle 3-character encodings", () => {
+          equal(base41.encode(1021), "wfBBBBB");
+          equal(base41.encode(65520), "DzxBBBB");
+          equal(base41.decode("wfBBBBB"), 1021);
+          equal(base41.decode("DzxBBBB"), 65520);
+        });
 
-            it("should handle 4-character encodings", () => {
-              equal(base41.encode(65521), "FzxB");
-              equal(base41.encode(2097142), "rcWn");
-              equal(base41.decode("FzxB"), 65521);
-              equal(base41.decode("rcWn"), 2097142);
-            });
+        it("should handle 4-character encodings", () => {
+          equal(base41.encode(65521), "FzxBBBB");
+          equal(base41.encode(2097142), "rcWnBBB");
+          equal(base41.decode("FzxBBBB"), 65521);
+          equal(base41.decode("rcWnBBB"), 2097142);
+        });
 
-            it("should handle 5-character encodings", () => {
-              equal(base41.encode(2097143), "scWnB");
-              equal(base41.encode(67108858), "Wzknd");
-              equal(base41.decode("scWnB"), 2097143);
-              equal(base41.decode("Wzknd"), 67108858);
-            });
+        it("should handle 5-character encodings", () => {
+          equal(base41.encode(2097143), "scWnBBB");
+          equal(base41.encode(67108858), "WzkndBB");
+          equal(base41.decode("scWnBBB"), 2097143);
+          equal(base41.decode("WzkndBB"), 67108858);
+        });
 
-            it("should handle 6-character encodings", () => {
-              equal(base41.encode(67108859), "XzkndB");
-              equal(base41.encode(4294967290), "pQNxDw");
-              equal(base41.decode("XzkndB"), 67108859);
-              equal(base41.decode("pQNxDw"), 4294967290);
-            });
+        it("should handle 6-character encodings", () => {
+          equal(base41.encode(67108859), "XzkndBB");
+          equal(base41.encode(4294967290), "pQNxDwB");
+          equal(base41.decode("XzkndBB"), 67108859);
+          equal(base41.decode("pQNxDwB"), 4294967290);
+        });
 
-            it("should handle 7-character encodings", () => {
-              equal(base41.encode(4294967291), "qQNxDwB");
-              equal(base41.encode(137438953446), "NDDtPxk");
-              equal(base41.decode("qQNxDwB"), 4294967291);
-              equal(base41.decode("NDDtPxk"), 137438953446);
-            });
+        it("should handle 7-character encodings", () => {
+          equal(base41.encode(4294967291), "qQNxDwB");
+          equal(base41.encode(137438953446), "NDDtPxk");
+          equal(base41.decode("qQNxDwB"), 4294967291);
+          equal(base41.decode("NDDtPxk"), 137438953446);
+        });
 
-            it("should handle 8-character encodings", () => {
-              equal(base41.encode(137438953447), "PDDtPxkB");
-              equal(base41.encode(4398046511092), "rMgSNvdc");
-              equal(base41.decode("PDDtPxkB"), 137438953447);
-              equal(base41.decode("rMgSNvdc"), 4398046511092);
-            });
+        it("should handle 8-character encodings", () => {
+          equal(base41.encode(137438953447), "PDDtPxkB");
+          equal(base41.encode(4398046511092), "rMgSNvdc");
+          equal(base41.decode("PDDtPxkB"), 137438953447);
+          equal(base41.decode("rMgSNvdc"), 4398046511092);
+        });
 
-            it("should handle 9-character encodings", () => {
-              equal(base41.encode(4398046511093), "sMgSNvdcB");
-              equal(base41.encode(281474976710596), "qmVrJfPNt");
-              equal(base41.decode("sMgSNvdcB"), 4398046511093);
-              equal(base41.decode("qmVrJfPNt"), 281474976710596);
-            });
+        it("should handle 9-character encodings", () => {
+          equal(base41.encode(4398046511093), "sMgSNvdcB");
+          equal(base41.encode(281474976710596), "qmVrJfPNt");
+          equal(base41.decode("sMgSNvdcB"), 4398046511093);
+          equal(base41.decode("qmVrJfPNt"), 281474976710596);
+        });
 
-            it("should handle 10-character encodings", () => {
-              equal(base41.encode(281474976710597), "rmVrJfPNtB");
-              equal(base41.encode(9007199254740880), "FRFFRtCCbj");
-              equal(base41.decode("rmVrJfPNtB"), 281474976710597);
-              equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
-            });
+        it("should handle 10-character encodings", () => {
+          equal(base41.encode(281474976710597), "rmVrJfPNtB");
+          equal(base41.encode(9007199254740880), "FRFFRtCCbj");
+          equal(base41.decode("rmVrJfPNtB"), 281474976710597);
+          equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
+        });
 
-            it("should handle 11-character encodings", () => {
-              equal(base41.encode(9007199254740881), "GRFFRtCCbjB");
-              equal(base41.encode(288230376151711716n), "FRhVLdXrVYb");
-              equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
-              equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
-            });
+        it("should handle 11-character encodings", () => {
+          equal(base41.encode(9007199254740881), "GRFFRtCCbjB");
+          equal(base41.encode(288230376151711716n), "FRhVLdXrVYb");
+          equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
+          equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
+        });
 
-            it("should handle 12-character encodings", () => {
-              equal(base41.encode(288230376151711717n), "GRhVLdXrVYbB");
-              equal(base41.encode(18446744073709551556n), "xWGzGMzLNQbr");
-              equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
-              equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
-            });
-          });
+        it("should handle 12-character encodings", () => {
+          equal(base41.encode(288230376151711717n), "GRhVLdXrVYbB");
+          equal(base41.encode(18446744073709551556n), "xWGzGMzLNQbr");
+          equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
+          equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
+        });
+      });
 
-          describe("Multiple values", () => {
-            it("should handle 1-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBC");
-              equal(base41.encode(new BigUint64Array([40n, 40n])), "zBBBBBBBBBBBz");
-              deepEqual(base41.decode("CBBBBBBBBBBBC"), new BigUint64Array([1n, 1n]).buffer);
-              deepEqual(base41.decode("zBBBBBBBBBBBz"), new BigUint64Array([40n, 40n]).buffer);
-            });
+      describe("Multiple values", () => {
+        it("should handle 1-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBCBBBBBB");
+          equal(base41.encode(new BigUint64Array([40n, 40n])), "zBBBBBBBBBBBzBBBBBB");
+          deepEqual(base41.decode("CBBBBBBBBBBBCBBBBBB"), new BigUint64Array([1n, 1n]).buffer);
+          deepEqual(base41.decode("zBBBBBBBBBBBzBBBBBB"), new BigUint64Array([40n, 40n]).buffer);
+        });
 
-            it("should handle 2-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([41n, 41n])), "BCBBBBBBBBBBBC");
-              equal(base41.encode(new BigUint64Array([1020n, 1020n])), "vfBBBBBBBBBBvf");
-              deepEqual(base41.decode("BCBBBBBBBBBBBC"), new BigUint64Array([41n, 41n]).buffer);
-              deepEqual(base41.decode("vfBBBBBBBBBBvf"), new BigUint64Array([1020n, 1020n]).buffer);
-            });
+        it("should handle 2-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([41n, 41n])), "BCBBBBBBBBBBBCBBBBB");
+          equal(base41.encode(new BigUint64Array([1020n, 1020n])), "vfBBBBBBBBBBvfBBBBB");
+          deepEqual(base41.decode("BCBBBBBBBBBBBCBBBBB"), new BigUint64Array([41n, 41n]).buffer);
+          deepEqual(base41.decode("vfBBBBBBBBBBvfBBBBB"), new BigUint64Array([1020n, 1020n]).buffer);
+        });
 
-            it("should handle 3-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([1021n, 1021n])), "wfBBBBBBBBBBwfB");
-              equal(base41.encode(new BigUint64Array([65520n, 65520n])), "DzxBBBBBBBBBDzx");
-              deepEqual(base41.decode("wfBBBBBBBBBBwfB"), new BigUint64Array([1021n, 1021n]).buffer);
-              deepEqual(base41.decode("DzxBBBBBBBBBDzx"), new BigUint64Array([65520n, 65520n]).buffer);
-            });
+        it("should handle 3-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([1021n, 1021n])), "wfBBBBBBBBBBwfBBBBB");
+          equal(base41.encode(new BigUint64Array([65520n, 65520n])), "DzxBBBBBBBBBDzxBBBB");
+          deepEqual(base41.decode("wfBBBBBBBBBBwfBBBBB"), new BigUint64Array([1021n, 1021n]).buffer);
+          deepEqual(base41.decode("DzxBBBBBBBBBDzxBBBB"), new BigUint64Array([65520n, 65520n]).buffer);
+        });
 
-            it("should handle 10-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n])), "rmVrJfPNtBBBrmVrJfPNtB");
-              equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n])), "FRFFRtCCbjBBFRFFRtCCbj");
-              deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
-              deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
-            });
+        it("should handle 10-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n])), "rmVrJfPNtBBBrmVrJfPNtB");
+          equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n])), "FRFFRtCCbjBBFRFFRtCCbj");
+          deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
+          deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
+        });
 
-            it("should handle 11-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n])), "GRFFRtCCbjBBGRFFRtCCbjB");
-              equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n])), "FRhVLdXrVYbBFRhVLdXrVYb");
-              deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
-              deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
-            });
+        it("should handle 11-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n])), "GRFFRtCCbjBBGRFFRtCCbjB");
+          equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n])), "FRhVLdXrVYbBFRhVLdXrVYb");
+          deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
+          deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
+        });
 
-            it("should handle 12-character encodings", () => {
-              equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n])), "GRhVLdXrVYbBGRhVLdXrVYbB");
-              equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n])), "xWGzGMzLNQbrxWGzGMzLNQbr");
-              deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
-              deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
-            });
-          });
+        it("should handle 12-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n])), "GRhVLdXrVYbBGRhVLdXrVYbB");
+          equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n])), "xWGzGMzLNQbrxWGzGMzLNQbr");
+          deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
+          deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
+        });
+      });
+    });
+
+    describe("Explicit (multiple output lengths)", () => {
+      const base41 = new Base41({
+        outputs: [5, 7]
+      });
+
+      describe("Single value", () => {
+        it("should handle 1-character encodings", () => {
+          equal(base41.encode(1), "CBBBB");
+          equal(base41.encode(40), "zBBBB");
+          equal(base41.decode("CBBBB"), 1);
+          equal(base41.decode("zBBBB"), 40);
+        });
+
+        it("should handle 2-character encodings", () => {
+          equal(base41.encode(41), "BCBBB");
+          equal(base41.encode(1020), "vfBBB");
+          equal(base41.decode("BCBBB"), 41);
+          equal(base41.decode("vfBBB"), 1020);
+        });
+
+        it("should handle 3-character encodings", () => {
+          equal(base41.encode(1021), "wfBBB");
+          equal(base41.encode(65520), "DzxBB");
+          equal(base41.decode("wfBBB"), 1021);
+          equal(base41.decode("DzxBB"), 65520);
+        });
+
+        it("should handle 4-character encodings", () => {
+          equal(base41.encode(65521), "FzxBB");
+          equal(base41.encode(2097142), "rcWnB");
+          equal(base41.decode("FzxBB"), 65521);
+          equal(base41.decode("rcWnB"), 2097142);
+        });
+
+        it("should handle 5-character encodings", () => {
+          equal(base41.encode(2097143), "scWnB");
+          equal(base41.encode(67108858), "Wzknd");
+          equal(base41.decode("scWnB"), 2097143);
+          equal(base41.decode("Wzknd"), 67108858);
+        });
+
+        it("should handle 6-character encodings", () => {
+          equal(base41.encode(67108859), "XzkndBB");
+          equal(base41.encode(4294967290), "pQNxDwB");
+          equal(base41.decode("XzkndBB"), 67108859);
+          equal(base41.decode("pQNxDwB"), 4294967290);
+        });
+
+        it("should handle 7-character encodings", () => {
+          equal(base41.encode(4294967291), "qQNxDwB");
+          equal(base41.encode(137438953446), "NDDtPxk");
+          equal(base41.decode("qQNxDwB"), 4294967291);
+          equal(base41.decode("NDDtPxk"), 137438953446);
+        });
+
+        it("should handle 8-character encodings", () => {
+          equal(base41.encode(137438953447), "PDDtPxkB");
+          equal(base41.encode(4398046511092), "rMgSNvdc");
+          equal(base41.decode("PDDtPxkB"), 137438953447);
+          equal(base41.decode("rMgSNvdc"), 4398046511092);
+        });
+
+        it("should handle 9-character encodings", () => {
+          equal(base41.encode(4398046511093), "sMgSNvdcB");
+          equal(base41.encode(281474976710596), "qmVrJfPNt");
+          equal(base41.decode("sMgSNvdcB"), 4398046511093);
+          equal(base41.decode("qmVrJfPNt"), 281474976710596);
+        });
+
+        it("should handle 10-character encodings", () => {
+          equal(base41.encode(281474976710597), "rmVrJfPNtB");
+          equal(base41.encode(9007199254740880), "FRFFRtCCbj");
+          equal(base41.decode("rmVrJfPNtB"), 281474976710597);
+          equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
+        });
+
+        it("should handle 11-character encodings", () => {
+          equal(base41.encode(9007199254740881), "GRFFRtCCbjB");
+          equal(base41.encode(288230376151711716n), "FRhVLdXrVYb");
+          equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
+          equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
+        });
+
+        it("should handle 12-character encodings", () => {
+          equal(base41.encode(288230376151711717n), "GRhVLdXrVYbB");
+          equal(base41.encode(18446744073709551556n), "xWGzGMzLNQbr");
+          equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
+          equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
+        });
+      });
+
+      describe("Multiple values", () => {
+        it("should handle 1-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBCBBBB");
+          equal(base41.encode(new BigUint64Array([40n, 40n])), "zBBBBBBBBBBBzBBBB");
+          deepEqual(base41.decode("CBBBBBBBBBBBCBBBB"), new BigUint64Array([1n, 1n]).buffer);
+          deepEqual(base41.decode("zBBBBBBBBBBBzBBBB"), new BigUint64Array([40n, 40n]).buffer);
+        });
+
+        it("should handle 2-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([41n, 41n])), "BCBBBBBBBBBBBCBBB");
+          equal(base41.encode(new BigUint64Array([1020n, 1020n])), "vfBBBBBBBBBBvfBBB");
+          deepEqual(base41.decode("BCBBBBBBBBBBBCBBB"), new BigUint64Array([41n, 41n]).buffer);
+          deepEqual(base41.decode("vfBBBBBBBBBBvfBBB"), new BigUint64Array([1020n, 1020n]).buffer);
+        });
+
+        it("should handle 3-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([1021n, 1021n])), "wfBBBBBBBBBBwfBBB");
+          equal(base41.encode(new BigUint64Array([65520n, 65520n])), "DzxBBBBBBBBBDzxBB");
+          deepEqual(base41.decode("wfBBBBBBBBBBwfBBB"), new BigUint64Array([1021n, 1021n]).buffer);
+          deepEqual(base41.decode("DzxBBBBBBBBBDzxBB"), new BigUint64Array([65520n, 65520n]).buffer);
+        });
+
+        it("should handle 10-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n])), "rmVrJfPNtBBBrmVrJfPNtB");
+          equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n])), "FRFFRtCCbjBBFRFFRtCCbj");
+          deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
+          deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
+        });
+
+        it("should handle 11-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n])), "GRFFRtCCbjBBGRFFRtCCbjB");
+          equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n])), "FRhVLdXrVYbBFRhVLdXrVYb");
+          deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
+          deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
+        });
+
+        it("should handle 12-character encodings", () => {
+          equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n])), "GRhVLdXrVYbBGRhVLdXrVYbB");
+          equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n])), "xWGzGMzLNQbrxWGzGMzLNQbr");
+          deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
+          deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
         });
       });
     });
@@ -780,86 +447,86 @@ describe("Base41", () => {
 
     it("should handle 1-character encodings", () => {
       equal(base41.encode(1), "F");
-      equal(base41.encode(31), "T");
+      equal(base41.encode(40), "C");
       equal(base41.decode("F"), 1);
-      equal(base41.decode("T"), 31);
+      equal(base41.decode("C"), 40);
     });
 
     it("should handle 2-character encodings", () => {
-      equal(base41.encode(32), "ft");
-      equal(base41.encode(1023), "GD");
-      equal(base41.decode("ft"), 32);
-      equal(base41.decode("GD"), 1023);
+      equal(base41.encode(41), "tF");
+      equal(base41.encode(1020), "MD");
+      equal(base41.decode("tF"), 41);
+      equal(base41.decode("MD"), 1020);
     });
 
     it("should handle 3-character encodings", () => {
-      equal(base41.encode(1024), "CDt");
-      equal(base41.encode(65535), "WCH");
-      equal(base41.decode("CDt"), 1024);
-      equal(base41.decode("WCH"), 65535);
+      equal(base41.encode(1021), "vDt");
+      equal(base41.encode(65520), "VCH");
+      equal(base41.decode("vDt"), 1021);
+      equal(base41.decode("VCH"), 65520);
     });
 
     it("should handle 4-character encodings", () => {
-      equal(base41.encode(65536), "wCHt");
-      equal(base41.encode(2097151), "FpWK");
-      equal(base41.decode("wCHt"), 65536);
-      equal(base41.decode("FpWK"), 2097151);
+      equal(base41.encode(65521), "XCHt");
+      equal(base41.encode(2097142), "gBWK");
+      equal(base41.decode("XCHt"), 65521);
+      equal(base41.decode("gBWK"), 2097142);
     });
 
     it("should handle 5-character encodings", () => {
-      equal(base41.encode(2097152), "VpWKt");
-      equal(base41.encode(67108863), "BCjKp");
-      equal(base41.decode("VpWKt"), 2097152);
-      equal(base41.decode("BCjKp"), 67108863);
+      equal(base41.encode(2097143), "ZBWKt");
+      equal(base41.encode(67108858), "WCjKp");
+      equal(base41.decode("ZBWKt"), 2097143);
+      equal(base41.decode("WCjKp"), 67108858);
     });
 
     it("should handle 6-character encodings", () => {
-      equal(base41.encode(67108864), "pCjKpt");
-      equal(base41.encode(4294967295), "MnxHVv");
-      equal(base41.decode("pCjKpt"), 67108864);
-      equal(base41.decode("MnxHVv"), 4294967295);
+      equal(base41.encode(67108859), "wCjKpt");
+      equal(base41.encode(4294967290), "TnxHVv");
+      equal(base41.decode("wCjKpt"), 67108859);
+      equal(base41.decode("TnxHVv"), 4294967290);
     });
 
     it("should handle 7-character encodings", () => {
-      equal(base41.encode(4294967296), "vnxHVvt");
-      equal(base41.encode(137438953471), "NVVNrHj");
-      equal(base41.decode("vnxHVvt"), 4294967296);
-      equal(base41.decode("NVVNrHj"), 137438953471);
+      equal(base41.encode(4294967291), "fnxHVvt");
+      equal(base41.encode(137438953446), "xVVNrHj");
+      equal(base41.decode("fnxHVvt"), 4294967291);
+      equal(base41.decode("xVVNrHj"), 137438953446);
     });
 
     it("should handle 8-character encodings", () => {
-      equal(base41.encode(137438953472), "MVVNrHjt");
-      equal(base41.encode(4398046511103), "XxzkxMpB");
-      equal(base41.decode("MVVNrHjt"), 137438953472);
-      equal(base41.decode("XxzkxMpB"), 4398046511103);
+      equal(base41.encode(137438953447), "rVVNrHjt");
+      equal(base41.encode(4398046511092), "ghzkxMpB");
+      equal(base41.decode("rVVNrHjt"), 137438953447);
+      equal(base41.decode("ghzkxMpB"), 4398046511092);
     });
 
     it("should handle 9-character encodings", () => {
-      equal(base41.encode(4398046511104), "cxzkxMpBt");
-      equal(base41.encode(281474976710655), "hTJgbDrxN");
-      equal(base41.decode("cxzkxMpBt"), 4398046511104);
-      equal(base41.decode("hTJgbDrxN"), 281474976710655);
+      equal(base41.encode(4398046511093), "ZhzkxMpBt");
+      equal(base41.encode(281474976710596), "fQJgbDrxN");
+      equal(base41.decode("ZhzkxMpBt"), 4398046511093);
+      equal(base41.decode("fQJgbDrxN"), 281474976710596);
     });
 
     it("should handle 10-character encodings", () => {
-      equal(base41.encode(281474976710656), "xTJgbDrxNt");
-      equal(base41.encode(9007199254740991), "fRXXPNFFds");
-      equal(base41.decode("xTJgbDrxNt"), 281474976710656);
-      equal(base41.decode("fRXXPNFFds"), 9007199254740991);
+      equal(base41.encode(281474976710597), "gQJgbDrxNt");
+      equal(base41.encode(9007199254740880), "XPXXPNFFds");
+      equal(base41.decode("gQJgbDrxNt"), 281474976710597);
+      equal(base41.decode("XPXXPNFFds"), 9007199254740880);
     });
 
     it("should handle 11-character encodings", () => {
-      equal(base41.encode(9007199254740992n), "gRXXPNFFdst");
-      equal(base41.encode(288230376151711739n), "YPYJypwgJqd");
-      equal(base41.decode("gRXXPNFFdst"), 9007199254740992n);
-      equal(base41.decode("YPYJypwgJqd"), 288230376151711739n);
+      equal(base41.encode(9007199254740881), "cPXXPNFFdst");
+      equal(base41.encode(288230376151711716n), "XPYJypwgJqd");
+      equal(base41.decode("cPXXPNFFdst"), 9007199254740881);
+      equal(base41.decode("XPYJypwgJqd"), 288230376151711716n);
     });
 
     it("should handle 12-character encodings", () => {
-      equal(base41.encode(288230376151711740n), "sPYJypwgJqdt");
-      equal(base41.encode(18446744073709551615n), "RqcCchCyxndg");
-      equal(base41.decode("sPYJypwgJqdt"), 288230376151711740n);
-      equal(base41.decode("RqcCchCyxndg"), 18446744073709551615n);
+      equal(base41.encode(288230376151711717n), "cPYJypwgJqdt");
+      equal(base41.encode(18446744073709551556n), "HWcCchCyxndg");
+      equal(base41.decode("cPYJypwgJqdt"), 288230376151711717n);
+      equal(base41.decode("HWcCchCyxndg"), 18446744073709551556n);
     });
   });
 });

--- a/test/Base41.test.ts
+++ b/test/Base41.test.ts
@@ -11,520 +11,245 @@ describe("Base41", () => {
       equal(typeof base41.decode, "function");
     });
 
-    it("should throw error if invalid seed provided", () => {
-      try {
-        new Base41({
-          seed: new Uint8Array([1])
-        });
-      } catch (error) {
-        equal(error instanceof RangeError, true);
-        equal((error as RangeError).message, "If seed is provided it must be 24 bytes long.");
-      }
+    it("should pad the seed if less than 24 bytes provided", () => {
+      const base41 = new Base41(new Uint8Array([1]));
+      equal(base41.encode(1, 1), "D");
+      equal(base41.encode(40, 1), "B");
+      equal(base41.decode("D"), 1);
+      equal(base41.decode("B"), 40);
     });
   });
 
   describe("Unseeded", () => {
-    describe("Adaptive", () => {
-      const base41 = new Base41();
+    const base41 = new Base41();
 
-      describe("Single value", () => {
-        it("should handle 1-character encodings", () => {
-          equal(base41.encode(1), "C");
-          equal(base41.encode(40), "z");
-          equal(base41.decode("C"), 1);
-          equal(base41.decode("z"), 40);
-        });
-
-        it("should handle 2-character encodings", () => {
-          equal(base41.encode(41), "BC");
-          equal(base41.encode(1020), "vf");
-          equal(base41.decode("BC"), 41);
-          equal(base41.decode("vf"), 1020);
-        });
-
-        it("should handle 3-character encodings", () => {
-          equal(base41.encode(1021), "wfB");
-          equal(base41.encode(65520), "Dzx");
-          equal(base41.decode("wfB"), 1021);
-          equal(base41.decode("Dzx"), 65520);
-        });
-
-        it("should handle 4-character encodings", () => {
-          equal(base41.encode(65521), "FzxB");
-          equal(base41.encode(2097142), "rcWn");
-          equal(base41.decode("FzxB"), 65521);
-          equal(base41.decode("rcWn"), 2097142);
-        });
-
-        it("should handle 5-character encodings", () => {
-          equal(base41.encode(2097143), "scWnB");
-          equal(base41.encode(67108858), "Wzknd");
-          equal(base41.decode("scWnB"), 2097143);
-          equal(base41.decode("Wzknd"), 67108858);
-        });
-
-        it("should handle 6-character encodings", () => {
-          equal(base41.encode(67108859), "XzkndB");
-          equal(base41.encode(4294967290), "pQNxDw");
-          equal(base41.decode("XzkndB"), 67108859);
-          equal(base41.decode("pQNxDw"), 4294967290);
-        });
-
-        it("should handle 7-character encodings", () => {
-          equal(base41.encode(4294967291), "qQNxDwB");
-          equal(base41.encode(137438953446), "NDDtPxk");
-          equal(base41.decode("qQNxDwB"), 4294967291);
-          equal(base41.decode("NDDtPxk"), 137438953446);
-        });
-
-        it("should handle 8-character encodings", () => {
-          equal(base41.encode(137438953447), "PDDtPxkB");
-          equal(base41.encode(4398046511092), "rMgSNvdc");
-          equal(base41.decode("PDDtPxkB"), 137438953447);
-          equal(base41.decode("rMgSNvdc"), 4398046511092);
-        });
-
-        it("should handle 9-character encodings", () => {
-          equal(base41.encode(4398046511093), "sMgSNvdcB");
-          equal(base41.encode(281474976710596), "qmVrJfPNt");
-          equal(base41.decode("sMgSNvdcB"), 4398046511093);
-          equal(base41.decode("qmVrJfPNt"), 281474976710596);
-        });
-
-        it("should handle 10-character encodings", () => {
-          equal(base41.encode(281474976710597), "rmVrJfPNtB");
-          equal(base41.encode(9007199254740880), "FRFFRtCCbj");
-          equal(base41.decode("rmVrJfPNtB"), 281474976710597);
-          equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
-        });
-
-        it("should handle 11-character encodings", () => {
-          equal(base41.encode(9007199254740881), "GRFFRtCCbjB");
-          equal(base41.encode(288230376151711716n), "FRhVLdXrVYb");
-          equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
-          equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
-        });
-
-        it("should handle 12-character encodings", () => {
-          equal(base41.encode(288230376151711717n), "GRhVLdXrVYbB");
-          equal(base41.encode(18446744073709551556n), "xWGzGMzLNQbr");
-          equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
-          equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
-        });
+    describe("Single value", () => {
+      it("should handle 1-character encodings", () => {
+        equal(base41.encode(1, 1), "C");
+        equal(base41.encode(1, 2), "CB");
+        equal(base41.encode(40, 1), "z");
+        equal(base41.encode(40, 2), "zB");
+        equal(base41.decode("C"), 1);
+        equal(base41.decode("CB"), 1);
+        equal(base41.decode("z"), 40);
+        equal(base41.decode("zB"), 40);
       });
 
-      describe("Multiple values", () => {
-        it("should handle 1-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBC");
-          equal(base41.encode(new BigUint64Array([40n, 40n])), "zBBBBBBBBBBBz");
-          deepEqual(base41.decode("CBBBBBBBBBBBC"), new BigUint64Array([1n, 1n]).buffer);
-          deepEqual(base41.decode("zBBBBBBBBBBBz"), new BigUint64Array([40n, 40n]).buffer);
-        });
+      it("should handle 2-character encodings", () => {
+        equal(base41.encode(41, 2), "BC");
+        equal(base41.encode(1020, 2), "vf");
+        equal(base41.decode("BC"), 41);
+        equal(base41.decode("vf"), 1020);
+      });
 
-        it("should handle 2-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([41n, 41n])), "BCBBBBBBBBBBBC");
-          equal(base41.encode(new BigUint64Array([1020n, 1020n])), "vfBBBBBBBBBBvf");
-          deepEqual(base41.decode("BCBBBBBBBBBBBC"), new BigUint64Array([41n, 41n]).buffer);
-          deepEqual(base41.decode("vfBBBBBBBBBBvf"), new BigUint64Array([1020n, 1020n]).buffer);
-        });
+      it("should handle 3-character encodings", () => {
+        equal(base41.encode(1021, 3), "wfB");
+        equal(base41.encode(65520, 3), "Dzx");
+        equal(base41.decode("wfB"), 1021);
+        equal(base41.decode("Dzx"), 65520);
+      });
 
-        it("should handle 3-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([1021n, 1021n])), "wfBBBBBBBBBBwfB");
-          equal(base41.encode(new BigUint64Array([65520n, 65520n])), "DzxBBBBBBBBBDzx");
-          deepEqual(base41.decode("wfBBBBBBBBBBwfB"), new BigUint64Array([1021n, 1021n]).buffer);
-          deepEqual(base41.decode("DzxBBBBBBBBBDzx"), new BigUint64Array([65520n, 65520n]).buffer);
-        });
+      it("should handle 4-character encodings", () => {
+        equal(base41.encode(65521, 4), "FzxB");
+        equal(base41.encode(2097142, 4), "rcWn");
+        equal(base41.decode("FzxB"), 65521);
+        equal(base41.decode("rcWn"), 2097142);
+      });
 
-        it("should handle 10-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n])), "rmVrJfPNtBBBrmVrJfPNtB");
-          equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n])), "FRFFRtCCbjBBFRFFRtCCbj");
-          deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
-          deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
-        });
+      it("should handle 5-character encodings", () => {
+        equal(base41.encode(2097143, 5), "scWnB");
+        equal(base41.encode(67108858, 5), "Wzknd");
+        equal(base41.decode("scWnB"), 2097143);
+        equal(base41.decode("Wzknd"), 67108858);
+      });
 
-        it("should handle 11-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n])), "GRFFRtCCbjBBGRFFRtCCbjB");
-          equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n])), "FRhVLdXrVYbBFRhVLdXrVYb");
-          deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
-          deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
-        });
+      it("should handle 6-character encodings", () => {
+        equal(base41.encode(67108859, 6), "XzkndB");
+        equal(base41.encode(4294967290, 6), "pQNxDw");
+        equal(base41.decode("XzkndB"), 67108859);
+        equal(base41.decode("pQNxDw"), 4294967290);
+      });
 
-        it("should handle 12-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n])), "GRhVLdXrVYbBGRhVLdXrVYbB");
-          equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n])), "xWGzGMzLNQbrxWGzGMzLNQbr");
-          deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
-          deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
-        });
+      it("should handle 7-character encodings", () => {
+        equal(base41.encode(4294967291, 7), "qQNxDwB");
+        equal(base41.encode(137438953446, 7), "NDDtPxk");
+        equal(base41.decode("qQNxDwB"), 4294967291);
+        equal(base41.decode("NDDtPxk"), 137438953446);
+      });
+
+      it("should handle 8-character encodings", () => {
+        equal(base41.encode(137438953447, 8), "PDDtPxkB");
+        equal(base41.encode(4398046511092, 8), "rMgSNvdc");
+        equal(base41.decode("PDDtPxkB"), 137438953447);
+        equal(base41.decode("rMgSNvdc"), 4398046511092);
+      });
+
+      it("should handle 9-character encodings", () => {
+        equal(base41.encode(4398046511093, 9), "sMgSNvdcB");
+        equal(base41.encode(281474976710596, 9), "qmVrJfPNt");
+        equal(base41.decode("sMgSNvdcB"), 4398046511093);
+        equal(base41.decode("qmVrJfPNt"), 281474976710596);
+      });
+
+      it("should handle 10-character encodings", () => {
+        equal(base41.encode(281474976710597, 10), "rmVrJfPNtB");
+        equal(base41.encode(9007199254740880, 10), "FRFFRtCCbj");
+        equal(base41.decode("rmVrJfPNtB"), 281474976710597);
+        equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
+      });
+
+      it("should handle 11-character encodings", () => {
+        equal(base41.encode(9007199254740881, 11), "GRFFRtCCbjB");
+        equal(base41.encode(288230376151711716n, 11), "FRhVLdXrVYb");
+        equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
+        equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
+      });
+
+      it("should handle 12-character encodings", () => {
+        equal(base41.encode(288230376151711717n, 12), "GRhVLdXrVYbB");
+        equal(base41.encode(18446744073709551556n, 12), "xWGzGMzLNQbr");
+        equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
+        equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
       });
     });
 
-    describe("Fluid (single output length)", () => {
-      const base41 = new Base41({
-        outputs: 7
+    describe("Multiple values", () => {
+      it("should handle 1-character encodings", () => {
+        equal(base41.encode(new BigUint64Array([1n, 1n]), 1), "CBBBBBBBBBBBC");
+        equal(base41.encode(new BigUint64Array([40n, 40n]), 1), "zBBBBBBBBBBBz");
+        deepEqual(base41.decode("CBBBBBBBBBBBC"), new BigUint64Array([1n, 1n]).buffer);
+        deepEqual(base41.decode("zBBBBBBBBBBBz"), new BigUint64Array([40n, 40n]).buffer);
       });
 
-      describe("Single value", () => {
-        it("should handle 1-character encodings", () => {
-          equal(base41.encode(1), "CBBBBBB");
-          equal(base41.encode(40), "zBBBBBB");
-          equal(base41.decode("CBBBBBB"), 1);
-          equal(base41.decode("zBBBBBB"), 40);
-        });
-
-        it("should handle 2-character encodings", () => {
-          equal(base41.encode(41), "BCBBBBB");
-          equal(base41.encode(1020), "vfBBBBB");
-          equal(base41.decode("BCBBBBB"), 41);
-          equal(base41.decode("vfBBBBB"), 1020);
-        });
-
-        it("should handle 3-character encodings", () => {
-          equal(base41.encode(1021), "wfBBBBB");
-          equal(base41.encode(65520), "DzxBBBB");
-          equal(base41.decode("wfBBBBB"), 1021);
-          equal(base41.decode("DzxBBBB"), 65520);
-        });
-
-        it("should handle 4-character encodings", () => {
-          equal(base41.encode(65521), "FzxBBBB");
-          equal(base41.encode(2097142), "rcWnBBB");
-          equal(base41.decode("FzxBBBB"), 65521);
-          equal(base41.decode("rcWnBBB"), 2097142);
-        });
-
-        it("should handle 5-character encodings", () => {
-          equal(base41.encode(2097143), "scWnBBB");
-          equal(base41.encode(67108858), "WzkndBB");
-          equal(base41.decode("scWnBBB"), 2097143);
-          equal(base41.decode("WzkndBB"), 67108858);
-        });
-
-        it("should handle 6-character encodings", () => {
-          equal(base41.encode(67108859), "XzkndBB");
-          equal(base41.encode(4294967290), "pQNxDwB");
-          equal(base41.decode("XzkndBB"), 67108859);
-          equal(base41.decode("pQNxDwB"), 4294967290);
-        });
-
-        it("should handle 7-character encodings", () => {
-          equal(base41.encode(4294967291), "qQNxDwB");
-          equal(base41.encode(137438953446), "NDDtPxk");
-          equal(base41.decode("qQNxDwB"), 4294967291);
-          equal(base41.decode("NDDtPxk"), 137438953446);
-        });
-
-        it("should handle 8-character encodings", () => {
-          equal(base41.encode(137438953447), "PDDtPxkB");
-          equal(base41.encode(4398046511092), "rMgSNvdc");
-          equal(base41.decode("PDDtPxkB"), 137438953447);
-          equal(base41.decode("rMgSNvdc"), 4398046511092);
-        });
-
-        it("should handle 9-character encodings", () => {
-          equal(base41.encode(4398046511093), "sMgSNvdcB");
-          equal(base41.encode(281474976710596), "qmVrJfPNt");
-          equal(base41.decode("sMgSNvdcB"), 4398046511093);
-          equal(base41.decode("qmVrJfPNt"), 281474976710596);
-        });
-
-        it("should handle 10-character encodings", () => {
-          equal(base41.encode(281474976710597), "rmVrJfPNtB");
-          equal(base41.encode(9007199254740880), "FRFFRtCCbj");
-          equal(base41.decode("rmVrJfPNtB"), 281474976710597);
-          equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
-        });
-
-        it("should handle 11-character encodings", () => {
-          equal(base41.encode(9007199254740881), "GRFFRtCCbjB");
-          equal(base41.encode(288230376151711716n), "FRhVLdXrVYb");
-          equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
-          equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
-        });
-
-        it("should handle 12-character encodings", () => {
-          equal(base41.encode(288230376151711717n), "GRhVLdXrVYbB");
-          equal(base41.encode(18446744073709551556n), "xWGzGMzLNQbr");
-          equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
-          equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
-        });
+      it("should handle 2-character encodings", () => {
+        equal(base41.encode(new BigUint64Array([41n, 41n]), 2), "BCBBBBBBBBBBBC");
+        equal(base41.encode(new BigUint64Array([1020n, 1020n]), 2), "vfBBBBBBBBBBvf");
+        deepEqual(base41.decode("BCBBBBBBBBBBBC"), new BigUint64Array([41n, 41n]).buffer);
+        deepEqual(base41.decode("vfBBBBBBBBBBvf"), new BigUint64Array([1020n, 1020n]).buffer);
       });
 
-      describe("Multiple values", () => {
-        it("should handle 1-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBCBBBBBB");
-          equal(base41.encode(new BigUint64Array([40n, 40n])), "zBBBBBBBBBBBzBBBBBB");
-          deepEqual(base41.decode("CBBBBBBBBBBBCBBBBBB"), new BigUint64Array([1n, 1n]).buffer);
-          deepEqual(base41.decode("zBBBBBBBBBBBzBBBBBB"), new BigUint64Array([40n, 40n]).buffer);
-        });
-
-        it("should handle 2-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([41n, 41n])), "BCBBBBBBBBBBBCBBBBB");
-          equal(base41.encode(new BigUint64Array([1020n, 1020n])), "vfBBBBBBBBBBvfBBBBB");
-          deepEqual(base41.decode("BCBBBBBBBBBBBCBBBBB"), new BigUint64Array([41n, 41n]).buffer);
-          deepEqual(base41.decode("vfBBBBBBBBBBvfBBBBB"), new BigUint64Array([1020n, 1020n]).buffer);
-        });
-
-        it("should handle 3-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([1021n, 1021n])), "wfBBBBBBBBBBwfBBBBB");
-          equal(base41.encode(new BigUint64Array([65520n, 65520n])), "DzxBBBBBBBBBDzxBBBB");
-          deepEqual(base41.decode("wfBBBBBBBBBBwfBBBBB"), new BigUint64Array([1021n, 1021n]).buffer);
-          deepEqual(base41.decode("DzxBBBBBBBBBDzxBBBB"), new BigUint64Array([65520n, 65520n]).buffer);
-        });
-
-        it("should handle 10-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n])), "rmVrJfPNtBBBrmVrJfPNtB");
-          equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n])), "FRFFRtCCbjBBFRFFRtCCbj");
-          deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
-          deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
-        });
-
-        it("should handle 11-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n])), "GRFFRtCCbjBBGRFFRtCCbjB");
-          equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n])), "FRhVLdXrVYbBFRhVLdXrVYb");
-          deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
-          deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
-        });
-
-        it("should handle 12-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n])), "GRhVLdXrVYbBGRhVLdXrVYbB");
-          equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n])), "xWGzGMzLNQbrxWGzGMzLNQbr");
-          deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
-          deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
-        });
-      });
-    });
-
-    describe("Explicit (multiple output lengths)", () => {
-      const base41 = new Base41({
-        outputs: [5, 7]
+      it("should handle 3-character encodings", () => {
+        equal(base41.encode(new BigUint64Array([1021n, 1021n]), 3), "wfBBBBBBBBBBwfB");
+        equal(base41.encode(new BigUint64Array([65520n, 65520n]), 3), "DzxBBBBBBBBBDzx");
+        deepEqual(base41.decode("wfBBBBBBBBBBwfB"), new BigUint64Array([1021n, 1021n]).buffer);
+        deepEqual(base41.decode("DzxBBBBBBBBBDzx"), new BigUint64Array([65520n, 65520n]).buffer);
       });
 
-      describe("Single value", () => {
-        it("should handle 1-character encodings", () => {
-          equal(base41.encode(1), "CBBBB");
-          equal(base41.encode(40), "zBBBB");
-          equal(base41.decode("CBBBB"), 1);
-          equal(base41.decode("zBBBB"), 40);
-        });
-
-        it("should handle 2-character encodings", () => {
-          equal(base41.encode(41), "BCBBB");
-          equal(base41.encode(1020), "vfBBB");
-          equal(base41.decode("BCBBB"), 41);
-          equal(base41.decode("vfBBB"), 1020);
-        });
-
-        it("should handle 3-character encodings", () => {
-          equal(base41.encode(1021), "wfBBB");
-          equal(base41.encode(65520), "DzxBB");
-          equal(base41.decode("wfBBB"), 1021);
-          equal(base41.decode("DzxBB"), 65520);
-        });
-
-        it("should handle 4-character encodings", () => {
-          equal(base41.encode(65521), "FzxBB");
-          equal(base41.encode(2097142), "rcWnB");
-          equal(base41.decode("FzxBB"), 65521);
-          equal(base41.decode("rcWnB"), 2097142);
-        });
-
-        it("should handle 5-character encodings", () => {
-          equal(base41.encode(2097143), "scWnB");
-          equal(base41.encode(67108858), "Wzknd");
-          equal(base41.decode("scWnB"), 2097143);
-          equal(base41.decode("Wzknd"), 67108858);
-        });
-
-        it("should handle 6-character encodings", () => {
-          equal(base41.encode(67108859), "XzkndBB");
-          equal(base41.encode(4294967290), "pQNxDwB");
-          equal(base41.decode("XzkndBB"), 67108859);
-          equal(base41.decode("pQNxDwB"), 4294967290);
-        });
-
-        it("should handle 7-character encodings", () => {
-          equal(base41.encode(4294967291), "qQNxDwB");
-          equal(base41.encode(137438953446), "NDDtPxk");
-          equal(base41.decode("qQNxDwB"), 4294967291);
-          equal(base41.decode("NDDtPxk"), 137438953446);
-        });
-
-        it("should handle 8-character encodings", () => {
-          equal(base41.encode(137438953447), "PDDtPxkB");
-          equal(base41.encode(4398046511092), "rMgSNvdc");
-          equal(base41.decode("PDDtPxkB"), 137438953447);
-          equal(base41.decode("rMgSNvdc"), 4398046511092);
-        });
-
-        it("should handle 9-character encodings", () => {
-          equal(base41.encode(4398046511093), "sMgSNvdcB");
-          equal(base41.encode(281474976710596), "qmVrJfPNt");
-          equal(base41.decode("sMgSNvdcB"), 4398046511093);
-          equal(base41.decode("qmVrJfPNt"), 281474976710596);
-        });
-
-        it("should handle 10-character encodings", () => {
-          equal(base41.encode(281474976710597), "rmVrJfPNtB");
-          equal(base41.encode(9007199254740880), "FRFFRtCCbj");
-          equal(base41.decode("rmVrJfPNtB"), 281474976710597);
-          equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
-        });
-
-        it("should handle 11-character encodings", () => {
-          equal(base41.encode(9007199254740881), "GRFFRtCCbjB");
-          equal(base41.encode(288230376151711716n), "FRhVLdXrVYb");
-          equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
-          equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
-        });
-
-        it("should handle 12-character encodings", () => {
-          equal(base41.encode(288230376151711717n), "GRhVLdXrVYbB");
-          equal(base41.encode(18446744073709551556n), "xWGzGMzLNQbr");
-          equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
-          equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
-        });
+      it("should handle 10-character encodings", () => {
+        equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n]), 10), "rmVrJfPNtBBBrmVrJfPNtB");
+        equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n]), 10), "FRFFRtCCbjBBFRFFRtCCbj");
+        deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
+        deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
       });
 
-      describe("Multiple values", () => {
-        it("should handle 1-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([1n, 1n])), "CBBBBBBBBBBBCBBBB");
-          equal(base41.encode(new BigUint64Array([40n, 40n])), "zBBBBBBBBBBBzBBBB");
-          deepEqual(base41.decode("CBBBBBBBBBBBCBBBB"), new BigUint64Array([1n, 1n]).buffer);
-          deepEqual(base41.decode("zBBBBBBBBBBBzBBBB"), new BigUint64Array([40n, 40n]).buffer);
-        });
+      it("should handle 11-character encodings", () => {
+        equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n]), 11), "GRFFRtCCbjBBGRFFRtCCbjB");
+        equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n]), 11), "FRhVLdXrVYbBFRhVLdXrVYb");
+        deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
+        deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
+      });
 
-        it("should handle 2-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([41n, 41n])), "BCBBBBBBBBBBBCBBB");
-          equal(base41.encode(new BigUint64Array([1020n, 1020n])), "vfBBBBBBBBBBvfBBB");
-          deepEqual(base41.decode("BCBBBBBBBBBBBCBBB"), new BigUint64Array([41n, 41n]).buffer);
-          deepEqual(base41.decode("vfBBBBBBBBBBvfBBB"), new BigUint64Array([1020n, 1020n]).buffer);
-        });
-
-        it("should handle 3-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([1021n, 1021n])), "wfBBBBBBBBBBwfBBB");
-          equal(base41.encode(new BigUint64Array([65520n, 65520n])), "DzxBBBBBBBBBDzxBB");
-          deepEqual(base41.decode("wfBBBBBBBBBBwfBBB"), new BigUint64Array([1021n, 1021n]).buffer);
-          deepEqual(base41.decode("DzxBBBBBBBBBDzxBB"), new BigUint64Array([65520n, 65520n]).buffer);
-        });
-
-        it("should handle 10-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n])), "rmVrJfPNtBBBrmVrJfPNtB");
-          equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n])), "FRFFRtCCbjBBFRFFRtCCbj");
-          deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
-          deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
-        });
-
-        it("should handle 11-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n])), "GRFFRtCCbjBBGRFFRtCCbjB");
-          equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n])), "FRhVLdXrVYbBFRhVLdXrVYb");
-          deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
-          deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
-        });
-
-        it("should handle 12-character encodings", () => {
-          equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n])), "GRhVLdXrVYbBGRhVLdXrVYbB");
-          equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n])), "xWGzGMzLNQbrxWGzGMzLNQbr");
-          deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
-          deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
-        });
+      it("should handle 12-character encodings", () => {
+        equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n]), 12), "GRhVLdXrVYbBGRhVLdXrVYbB");
+        equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n]), 12), "xWGzGMzLNQbrxWGzGMzLNQbr");
+        deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
+        deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
       });
     });
   });
 
-  describe("Seeded (default options)", () => {
-    const base41 = new Base41({
-      seed: new Uint8Array([
-        1, 2, 3, 4, 5, 6, 7, 8,
-        9, 10, 11, 12, 13, 14, 15, 16,
-        17, 18, 19, 20, 21, 22, 23, 24
-      ])
-    });
+  describe("Seeded", () => {
+    const base41 = new Base41(new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8,
+      9, 10, 11, 12, 13, 14, 15, 16,
+      17, 18, 19, 20, 21, 22, 23, 24
+    ]));
 
     it("should handle null character encodings", () => {
-      equal(base41.encode(0), "t");
+      equal(base41.encode(0, 1), "t");
       equal(base41.decode("t"), 0);
     });
 
     it("should handle 1-character encodings", () => {
-      equal(base41.encode(1), "F");
-      equal(base41.encode(40), "C");
+      equal(base41.encode(1, 1), "F");
+      equal(base41.encode(40, 1), "C");
       equal(base41.decode("F"), 1);
       equal(base41.decode("C"), 40);
     });
 
     it("should handle 2-character encodings", () => {
-      equal(base41.encode(41), "tF");
-      equal(base41.encode(1020), "MD");
+      equal(base41.encode(41, 2), "tF");
+      equal(base41.encode(1020, 2), "MD");
       equal(base41.decode("tF"), 41);
       equal(base41.decode("MD"), 1020);
     });
 
     it("should handle 3-character encodings", () => {
-      equal(base41.encode(1021), "vDt");
-      equal(base41.encode(65520), "VCH");
+      equal(base41.encode(1021, 3), "vDt");
+      equal(base41.encode(65520, 3), "VCH");
       equal(base41.decode("vDt"), 1021);
       equal(base41.decode("VCH"), 65520);
     });
 
     it("should handle 4-character encodings", () => {
-      equal(base41.encode(65521), "XCHt");
-      equal(base41.encode(2097142), "gBWK");
+      equal(base41.encode(65521, 4), "XCHt");
+      equal(base41.encode(2097142, 4), "gBWK");
       equal(base41.decode("XCHt"), 65521);
       equal(base41.decode("gBWK"), 2097142);
     });
 
     it("should handle 5-character encodings", () => {
-      equal(base41.encode(2097143), "ZBWKt");
-      equal(base41.encode(67108858), "WCjKp");
+      equal(base41.encode(2097143, 5), "ZBWKt");
+      equal(base41.encode(67108858, 5), "WCjKp");
       equal(base41.decode("ZBWKt"), 2097143);
       equal(base41.decode("WCjKp"), 67108858);
     });
 
     it("should handle 6-character encodings", () => {
-      equal(base41.encode(67108859), "wCjKpt");
-      equal(base41.encode(4294967290), "TnxHVv");
+      equal(base41.encode(67108859, 6), "wCjKpt");
+      equal(base41.encode(4294967290, 6), "TnxHVv");
       equal(base41.decode("wCjKpt"), 67108859);
       equal(base41.decode("TnxHVv"), 4294967290);
     });
 
     it("should handle 7-character encodings", () => {
-      equal(base41.encode(4294967291), "fnxHVvt");
-      equal(base41.encode(137438953446), "xVVNrHj");
+      equal(base41.encode(4294967291, 7), "fnxHVvt");
+      equal(base41.encode(137438953446, 7), "xVVNrHj");
       equal(base41.decode("fnxHVvt"), 4294967291);
       equal(base41.decode("xVVNrHj"), 137438953446);
     });
 
     it("should handle 8-character encodings", () => {
-      equal(base41.encode(137438953447), "rVVNrHjt");
-      equal(base41.encode(4398046511092), "ghzkxMpB");
+      equal(base41.encode(137438953447, 8), "rVVNrHjt");
+      equal(base41.encode(4398046511092, 8), "ghzkxMpB");
       equal(base41.decode("rVVNrHjt"), 137438953447);
       equal(base41.decode("ghzkxMpB"), 4398046511092);
     });
 
     it("should handle 9-character encodings", () => {
-      equal(base41.encode(4398046511093), "ZhzkxMpBt");
-      equal(base41.encode(281474976710596), "fQJgbDrxN");
+      equal(base41.encode(4398046511093, 9), "ZhzkxMpBt");
+      equal(base41.encode(281474976710596, 9), "fQJgbDrxN");
       equal(base41.decode("ZhzkxMpBt"), 4398046511093);
       equal(base41.decode("fQJgbDrxN"), 281474976710596);
     });
 
     it("should handle 10-character encodings", () => {
-      equal(base41.encode(281474976710597), "gQJgbDrxNt");
-      equal(base41.encode(9007199254740880), "XPXXPNFFds");
+      equal(base41.encode(281474976710597, 10), "gQJgbDrxNt");
+      equal(base41.encode(9007199254740880, 10), "XPXXPNFFds");
       equal(base41.decode("gQJgbDrxNt"), 281474976710597);
       equal(base41.decode("XPXXPNFFds"), 9007199254740880);
     });
 
     it("should handle 11-character encodings", () => {
-      equal(base41.encode(9007199254740881), "cPXXPNFFdst");
-      equal(base41.encode(288230376151711716n), "XPYJypwgJqd");
+      equal(base41.encode(9007199254740881, 11), "cPXXPNFFdst");
+      equal(base41.encode(288230376151711716n, 11), "XPYJypwgJqd");
       equal(base41.decode("cPXXPNFFdst"), 9007199254740881);
       equal(base41.decode("XPYJypwgJqd"), 288230376151711716n);
     });
 
     it("should handle 12-character encodings", () => {
-      equal(base41.encode(288230376151711717n), "cPYJypwgJqdt");
-      equal(base41.encode(18446744073709551556n), "HWcCchCyxndg");
+      equal(base41.encode(288230376151711717n, 12), "cPYJypwgJqdt");
+      equal(base41.encode(18446744073709551556n, 12), "HWcCchCyxndg");
       equal(base41.decode("cPYJypwgJqdt"), 288230376151711717n);
       equal(base41.decode("HWcCchCyxndg"), 18446744073709551556n);
     });

--- a/test/Generator.test.ts
+++ b/test/Generator.test.ts
@@ -221,8 +221,8 @@ describe("Generator", () => {
     });
 
     it("should handle unexpected bigint inputs", () => {
-      equal(generator.next(1n, 1), 37);
-      equal(generator.previous(37n, 1), 1);
+      equal(generator.next(1n, 1), 40);
+      equal(generator.previous(40n, 1), 1);
     });
 
     it("should compute values in mode 1", () => {
@@ -232,11 +232,11 @@ describe("Generator", () => {
       const prev3 = generator.previous(next3, 1);
       const prev2 = generator.previous(prev3, 1);
       const prev1 = generator.previous(prev2, 1);
-      equal(next1, 37);
-      equal(next2, 10);
-      equal(next3, 30);
-      equal(prev3, 10);
-      equal(prev2, 37);
+      equal(next1, 40);
+      equal(next2, 37);
+      equal(next3, 13);
+      equal(prev3, 37);
+      equal(prev2, 40);
       equal(prev1, 1);
     });
 
@@ -247,11 +247,11 @@ describe("Generator", () => {
       const prev3 = generator.previous(next3, 2);
       const prev2 = generator.previous(prev3, 2);
       const prev1 = generator.previous(prev2, 2);
-      equal(next1, 166);
-      equal(next2, 668);
-      equal(next3, 407);
-      equal(prev3, 668);
-      equal(prev2, 166);
+      equal(next1, 549);
+      equal(next2, 200);
+      equal(next3, 54);
+      equal(prev3, 200);
+      equal(prev2, 549);
       equal(prev1, 1);
     });
 
@@ -262,11 +262,11 @@ describe("Generator", () => {
       const prev3 = generator.previous(next3, 3);
       const prev2 = generator.previous(prev3, 3);
       const prev1 = generator.previous(prev2, 3);
-      equal(next1, 48459);
-      equal(next2, 52489);
-      equal(next3, 52981);
-      equal(prev3, 52489);
-      equal(prev2, 48459);
+      equal(next1, 4142);
+      equal(next2, 31929);
+      equal(next3, 28753);
+      equal(prev3, 31929);
+      equal(prev2, 4142);
       equal(prev1, 1);
     });
 
@@ -277,11 +277,11 @@ describe("Generator", () => {
       const prev3 = generator.previous(next3, 4);
       const prev2 = generator.previous(prev3, 4);
       const prev1 = generator.previous(prev2, 4);
-      equal(next1, 2057880);
-      equal(next2, 1663445);
-      equal(next3, 44273);
-      equal(prev3, 1663445);
-      equal(prev2, 2057880);
+      equal(next1, 2245);
+      equal(next2, 502285);
+      equal(next3, 768517);
+      equal(prev3, 502285);
+      equal(prev2, 2245);
       equal(prev1, 1);
     });
 
@@ -292,11 +292,11 @@ describe("Generator", () => {
       const prev3 = generator.previous(next3, 5);
       const prev2 = generator.previous(prev3, 5);
       const prev1 = generator.previous(prev2, 5);
-      equal(next1, 43629091);
-      equal(next2, 31550254);
-      equal(next3, 21619603);
-      equal(prev3, 31550254);
-      equal(prev2, 43629091);
+      equal(next1, 10120408);
+      equal(next2, 12043413);
+      equal(next3, 16875499);
+      equal(prev3, 12043413);
+      equal(prev2, 10120408);
       equal(prev1, 1);
     });
 
@@ -307,11 +307,11 @@ describe("Generator", () => {
       const prev3 = generator.previous(next3, 6);
       const prev2 = generator.previous(prev3, 6);
       const prev1 = generator.previous(prev2, 6);
-      equal(next1, 1826411712);
-      equal(next2, 2208974623);
-      equal(next3, 871136173);
-      equal(prev3, 2208974623);
-      equal(prev2, 1826411712);
+      equal(next1, 2048965993);
+      equal(next2, 2882355448);
+      equal(next3, 1358781941);
+      equal(prev3, 2882355448);
+      equal(prev2, 2048965993);
       equal(prev1, 1);
     });
 

--- a/test/Keymask.test.ts
+++ b/test/Keymask.test.ts
@@ -1,5 +1,5 @@
 import { equal } from "node:assert/strict";
-import { Keymask } from "../src/";
+import { Base41, Keymask } from "../src/";
 
 describe("Keymask", () => {
   describe("Default options", () => {
@@ -358,113 +358,112 @@ describe("Keymask", () => {
     });
   });
 
-  describe("Invalid seed", () => {
+  describe("Empty seed", () => {
     it("should create default instance if seed is empty", () => {
       const keymask = new Keymask({ seed: new Uint8Array(0) });
       equal(typeof keymask, "object");
 
-      equal(keymask.mask(288230376151711717n), "DjfkCZLtcBLn");
-      equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
-      equal(keymask.unmask("DjfkCZLtcBLn"), 288230376151711717n);
-      equal(keymask.unmask("YcWfgzxKYXFW"), 18446744073709551556n);
-    });
-
-    it("should create default instance if seed is too short", () => {
-      const keymask = new Keymask({ seed: new Uint8Array(7) });
-      equal(typeof keymask, "object");
-
-      equal(keymask.mask(288230376151711717n), "DjfkCZLtcBLn");
-      equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
-      equal(keymask.unmask("DjfkCZLtcBLn"), 288230376151711717n);
-      equal(keymask.unmask("YcWfgzxKYXFW"), 18446744073709551556n);
+      equal(keymask.mask(288230376151711717n), "FkgmDbMvdCMp");
+      equal(keymask.mask(18446744073709551556n), "ZdXghByLZYGX");
+      equal(keymask.unmask("FkgmDbMvdCMp"), 288230376151711717n);
+      equal(keymask.unmask("ZdXghByLZYGX"), 18446744073709551556n);
     });
   });
 
-  describe("Seed generator only", () => {
-    const keymask = new Keymask({ seed: new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]) });
+  describe("Given encoder instance", () => {
+    const keymask = new Keymask({
+      encoder: new Base41(new Uint8Array([
+        10, 20, 30, 40, 50, 60, 70, 80,
+        11, 21, 31, 41, 51, 61, 71, 81,
+        12, 22, 32, 42, 52, 62, 72, 82
+      ])),
+      seed: new Uint8Array([
+        13, 23, 33, 43, 53, 63, 73, 83
+      ])
+    });
 
     it("should mask and unmask in range 1", () => {
-      equal(keymask.mask(1), "J");
-      equal(keymask.mask(40), "F");
-      equal(keymask.unmask("J"), 1);
-      equal(keymask.unmask("F"), 40);
+      equal(keymask.mask(1), "m");
+      equal(keymask.mask(40), "M");
+      equal(keymask.unmask("m"), 1);
+      equal(keymask.unmask("M"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41), "kS");
-      equal(keymask.mask(1020), "Nf");
-      equal(keymask.unmask("kS"), 41);
-      equal(keymask.unmask("Nf"), 1020);
+      equal(keymask.mask(41), "Sb");
+      equal(keymask.mask(1020), "JV");
+      equal(keymask.unmask("Sb"), 41);
+      equal(keymask.unmask("JV"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021), "dHN");
-      equal(keymask.mask(65520), "xKV");
-      equal(keymask.unmask("dHN"), 1021);
-      equal(keymask.unmask("xKV"), 65520);
+      equal(keymask.mask(1021), "XCt");
+      equal(keymask.mask(65520), "rpv");
+      equal(keymask.unmask("XCt"), 1021);
+      equal(keymask.unmask("rpv"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521), "nZyB");
-      equal(keymask.mask(2097142), "nxyK");
-      equal(keymask.unmask("nZyB"), 65521);
-      equal(keymask.unmask("nxyK"), 2097142);
+      equal(keymask.mask(65521), "dCrv");
+      equal(keymask.mask(2097142), "dhrH");
+      equal(keymask.unmask("dCrv"), 65521);
+      equal(keymask.unmask("dhrH"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143), "jXxKF");
-      equal(keymask.mask(67108858), "mpstX");
-      equal(keymask.unmask("jXxKF"), 2097143);
-      equal(keymask.unmask("mpstX"), 67108858);
+      equal(keymask.mask(2097143), "qKnHS");
+      equal(keymask.mask(67108858), "gmFtM");
+      equal(keymask.unmask("qKnHS"), 2097143);
+      equal(keymask.unmask("gmFtM"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859), "NzrdMS");
-      equal(keymask.mask(4294967290), "chxQmF");
-      equal(keymask.unmask("NzrdMS"), 67108859);
-      equal(keymask.unmask("chxQmF"), 4294967290);
+      equal(keymask.mask(67108859), "CdBTKp");
+      equal(keymask.mask(4294967290), "HDnqhS");
+      equal(keymask.unmask("CdBTKp"), 67108859);
+      equal(keymask.unmask("HDnqhS"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {
-      equal(keymask.mask(4294967291), "NrjRcFG");
-      equal(keymask.mask(137438953446), "MTQXFCN");
-      equal(keymask.unmask("NrjRcFG"), 4294967291);
-      equal(keymask.unmask("MTQXFCN"), 137438953446);
+      equal(keymask.mask(4294967291), "QZtmmXn");
+      equal(keymask.mask(137438953446), "VSGJSdj");
+      equal(keymask.unmask("QZtmmXn"), 4294967291);
+      equal(keymask.unmask("VSGJSdj"), 137438953446);
     });
 
     it("should mask and unmask in range 8", () => {
-      equal(keymask.mask(137438953447), "vzyfBQQb");
-      equal(keymask.mask(4398046511092), "GzrFtkhL");
-      equal(keymask.unmask("vzyfBQQb"), 137438953447);
-      equal(keymask.unmask("GzrFtkhL"), 4398046511092);
+      equal(keymask.mask(137438953447), "jmFYpmhb");
+      equal(keymask.mask(4398046511092), "ZZycWTFS");
+      equal(keymask.unmask("jmFYpmhb"), 137438953447);
+      equal(keymask.unmask("ZZycWTFS"), 4398046511092);
     });
 
     it("should mask and unmask in range 9", () => {
-      equal(keymask.mask(4398046511093), "PNYnsCdMQ");
-      equal(keymask.mask(281474976710596), "qMTxVBYtB");
-      equal(keymask.unmask("PNYnsCdMQ"), 4398046511093);
-      equal(keymask.unmask("qMTxVBYtB"), 281474976710596);
+      equal(keymask.mask(4398046511093), "JjtTDrHJj");
+      equal(keymask.mask(281474976710596), "njnnsnMCB");
+      equal(keymask.unmask("JjtTDrHJj"), 4398046511093);
+      equal(keymask.unmask("njnnsnMCB"), 281474976710596);
     });
 
     it("should mask and unmask in range 10", () => {
-      equal(keymask.mask(281474976710597), "XnQbhDQZBL");
-      equal(keymask.mask(9007199254740880), "vtBzTJvyZh");
-      equal(keymask.unmask("XnQbhDQZBL"), 281474976710597);
-      equal(keymask.unmask("vtBzTJvyZh"), 9007199254740880);
+      equal(keymask.mask(281474976710597), "XnqngTcYVt");
+      equal(keymask.mask(9007199254740880), "rkjmnWqPVB");
+      equal(keymask.unmask("XnqngTcYVt"), 281474976710597);
+      equal(keymask.unmask("rkjmnWqPVB"), 9007199254740880);
     });
 
     it("should mask and unmask in range 11", () => {
-      equal(keymask.mask(9007199254740881n), "YQWwmfMCdtQ");
-      equal(keymask.mask(288230376151711716n), "fxrJDCrXLnX");
-      equal(keymask.unmask("YQWwmfMCdtQ"), 9007199254740881n);
-      equal(keymask.unmask("fxrJDCrXLnX"), 288230376151711716n);
+      equal(keymask.mask(9007199254740881n), "ZFPTtQhkBHr");
+      equal(keymask.mask(288230376151711716n), "JqfWVBjDqDz");
+      equal(keymask.unmask("ZFPTtQhkBHr"), 9007199254740881n);
+      equal(keymask.unmask("JqfWVBjDqDz"), 288230376151711716n);
     });
 
     it("should mask and unmask in range 12", () => {
-      equal(keymask.mask(288230376151711717n), "rMXDsXwqvhKK");
-      equal(keymask.mask(18446744073709551556n), "JdTxbKhSDVfj");
-      equal(keymask.unmask("rMXDsXwqvhKK"), 288230376151711717n);
-      equal(keymask.unmask("JdTxbKhSDVfj"), 18446744073709551556n);
+      equal(keymask.mask(288230376151711717n), "NjdfHBwHxXHr");
+      equal(keymask.mask(18446744073709551556n), "CJqbCdHcTmkY");
+      equal(keymask.unmask("NjdfHBwHxXHr"), 288230376151711717n);
+      equal(keymask.unmask("CJqbCdHcTmkY"), 18446744073709551556n);
     });
   });
 
@@ -573,87 +572,87 @@ describe("Keymask", () => {
     });
 
     it("should mask and unmask in range 1", () => {
-      equal(keymask.mask(1), "Y");
-      equal(keymask.mask(40), "p");
-      equal(keymask.unmask("Y"), 1);
-      equal(keymask.unmask("p"), 40);
+      equal(keymask.mask(1), "m");
+      equal(keymask.mask(40), "M");
+      equal(keymask.unmask("m"), 1);
+      equal(keymask.unmask("M"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41), "cn");
-      equal(keymask.mask(1020), "Dm");
-      equal(keymask.unmask("cn"), 41);
-      equal(keymask.unmask("Dm"), 1020);
+      equal(keymask.mask(41), "Sb");
+      equal(keymask.mask(1020), "JV");
+      equal(keymask.unmask("Sb"), 41);
+      equal(keymask.unmask("JV"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021), "GHD");
-      equal(keymask.mask(65520), "MZQ");
-      equal(keymask.unmask("GHD"), 1021);
-      equal(keymask.unmask("MZQ"), 65520);
+      equal(keymask.mask(1021), "XCt");
+      equal(keymask.mask(65520), "rpv");
+      equal(keymask.unmask("XCt"), 1021);
+      equal(keymask.unmask("rpv"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521), "PNCh");
-      equal(keymask.mask(2097142), "PMCZ");
-      equal(keymask.unmask("PNCh"), 65521);
-      equal(keymask.unmask("PMCZ"), 2097142);
+      equal(keymask.mask(65521), "dCrv");
+      equal(keymask.mask(2097142), "dhrH");
+      equal(keymask.unmask("dCrv"), 65521);
+      equal(keymask.unmask("dhrH"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143), "SgMZp");
-      equal(keymask.mask(67108858), "WjTVg");
-      equal(keymask.unmask("SgMZp"), 2097143);
-      equal(keymask.unmask("WjTVg"), 67108858);
+      equal(keymask.mask(2097143), "qKnHS");
+      equal(keymask.mask(67108858), "gmFtM");
+      equal(keymask.unmask("qKnHS"), 2097143);
+      equal(keymask.unmask("gmFtM"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859), "DrFGkn");
-      equal(keymask.mask(4294967290), "ysMKWp");
-      equal(keymask.unmask("DrFGkn"), 67108859);
-      equal(keymask.unmask("ysMKWp"), 4294967290);
+      equal(keymask.mask(67108859), "CdBTKp");
+      equal(keymask.mask(4294967290), "HDnqhS");
+      equal(keymask.unmask("CdBTKp"), 67108859);
+      equal(keymask.unmask("HDnqhS"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {
-      equal(keymask.mask(4294967291), "DFSRypq");
-      equal(keymask.mask(137438953446), "kfKgpbD");
-      equal(keymask.unmask("DFSRypq"), 4294967291);
-      equal(keymask.unmask("kfKgpbD"), 137438953446);
+      equal(keymask.mask(4294967291), "QZtmmXn");
+      equal(keymask.mask(137438953446), "VSGJSdj");
+      equal(keymask.unmask("QZtmmXn"), 4294967291);
+      equal(keymask.unmask("VSGJSdj"), 137438953446);
     });
 
     it("should mask and unmask in range 8", () => {
-      equal(keymask.mask(137438953447), "BrCmhKKw");
-      equal(keymask.mask(4398046511092), "qrFpVcsz");
-      equal(keymask.unmask("BrCmhKKw"), 137438953447);
-      equal(keymask.unmask("qrFpVcsz"), 4398046511092);
+      equal(keymask.mask(137438953447), "jmFYpmhb");
+      equal(keymask.mask(4398046511092), "ZZycWTFS");
+      equal(keymask.unmask("jmFYpmhb"), 137438953447);
+      equal(keymask.unmask("ZZycWTFS"), 4398046511092);
     });
 
     it("should mask and unmask in range 9", () => {
-      equal(keymask.mask(4398046511093), "vDxPTbGkK");
-      equal(keymask.mask(281474976710596), "LkfMQhxVh");
-      equal(keymask.unmask("vDxPTbGkK"), 4398046511093);
-      equal(keymask.unmask("LkfMQhxVh"), 281474976710596);
+      equal(keymask.mask(4398046511093), "JjtTDrHJj");
+      equal(keymask.mask(281474976710596), "njnnsnMCB");
+      equal(keymask.unmask("JjtTDrHJj"), 4398046511093);
+      equal(keymask.unmask("njnnsnMCB"), 281474976710596);
     });
 
     it("should mask and unmask in range 10", () => {
-      equal(keymask.mask(281474976710597), "gPKwstKNhz");
-      equal(keymask.mask(9007199254740880), "BVhrfYBCNs");
-      equal(keymask.unmask("gPKwstKNhz"), 281474976710597);
-      equal(keymask.unmask("BVhrfYBCNs"), 9007199254740880);
+      equal(keymask.mask(281474976710597), "XnqngTcYVt");
+      equal(keymask.mask(9007199254740880), "rkjmnWqPVB");
+      equal(keymask.unmask("XnqngTcYVt"), 281474976710597);
+      equal(keymask.unmask("rkjmnWqPVB"), 9007199254740880);
     });
 
     it("should mask and unmask in range 11", () => {
-      equal(keymask.mask(9007199254740881n), "xKdJWmkbGVK");
-      equal(keymask.mask(288230376151711716n), "mMFYtbFgzPg");
-      equal(keymask.unmask("xKdJWmkbGVK"), 9007199254740881n);
-      equal(keymask.unmask("mMFYtbFgzPg"), 288230376151711716n);
+      equal(keymask.mask(9007199254740881n), "ZFPTtQhkBHr");
+      equal(keymask.mask(288230376151711716n), "JqfWVBjDqDz");
+      equal(keymask.unmask("ZFPTtQhkBHr"), 9007199254740881n);
+      equal(keymask.unmask("JqfWVBjDqDz"), 288230376151711716n);
     });
 
     it("should mask and unmask in range 12", () => {
-      equal(keymask.mask(288230376151711717n), "FkgtTgJLBsZZ");
-      equal(keymask.mask(18446744073709551556n), "YGfMwZsntQmS");
-      equal(keymask.unmask("FkgtTgJLBsZZ"), 288230376151711717n);
-      equal(keymask.unmask("YGfMwZsntQmS"), 18446744073709551556n);
+      equal(keymask.mask(288230376151711717n), "NjdfHBwHxXHr");
+      equal(keymask.mask(18446744073709551556n), "CJqbCdHcTmkY");
+      equal(keymask.unmask("NjdfHBwHxXHr"), 288230376151711717n);
+      equal(keymask.unmask("CJqbCdHcTmkY"), 18446744073709551556n);
     });
   });
 });

--- a/test/Keymask.test.ts
+++ b/test/Keymask.test.ts
@@ -294,45 +294,45 @@ describe("Keymask", () => {
     const keymask = new Keymask({ seed: new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]) });
 
     it("should mask and unmask in range 1", () => {
-      equal(keymask.mask(1), "q");
-      equal(keymask.mask(40), "m");
-      equal(keymask.unmask("q"), 1);
-      equal(keymask.unmask("m"), 40);
+      equal(keymask.mask(1), "J");
+      equal(keymask.mask(40), "F");
+      equal(keymask.unmask("J"), 1);
+      equal(keymask.unmask("F"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41), "Jc");
-      equal(keymask.mask(1020), "sJ");
-      equal(keymask.unmask("Jc"), 41);
-      equal(keymask.unmask("sJ"), 1020);
+      equal(keymask.mask(41), "kS");
+      equal(keymask.mask(1020), "Nf");
+      equal(keymask.unmask("kS"), 41);
+      equal(keymask.unmask("Nf"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021), "zXJ");
-      equal(keymask.mask(65520), "SbQ");
-      equal(keymask.unmask("zXJ"), 1021);
-      equal(keymask.unmask("SbQ"), 65520);
+      equal(keymask.mask(1021), "dHN");
+      equal(keymask.mask(65520), "xKV");
+      equal(keymask.unmask("dHN"), 1021);
+      equal(keymask.unmask("xKV"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521), "qbZJ");
-      equal(keymask.mask(2097142), "qyZR");
-      equal(keymask.unmask("qbZJ"), 65521);
-      equal(keymask.unmask("qyZR"), 2097142);
+      equal(keymask.mask(65521), "nZyB");
+      equal(keymask.mask(2097142), "nxyK");
+      equal(keymask.unmask("nZyB"), 65521);
+      equal(keymask.unmask("nxyK"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143), "PGmsC");
-      equal(keymask.mask(67108858), "RWgbW");
-      equal(keymask.unmask("PGmsC"), 2097143);
-      equal(keymask.unmask("RWgbW"), 67108858);
+      equal(keymask.mask(2097143), "jXxKF");
+      equal(keymask.mask(67108858), "mpstX");
+      equal(keymask.unmask("jXxKF"), 2097143);
+      equal(keymask.unmask("mpstX"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859), "hdpyPt");
-      equal(keymask.mask(4294967290), "xMvkpf");
-      equal(keymask.unmask("hdpyPt"), 67108859);
-      equal(keymask.unmask("xMvkpf"), 4294967290);
+      equal(keymask.mask(67108859), "NzrdMS");
+      equal(keymask.mask(4294967290), "chxQmF");
+      equal(keymask.unmask("NzrdMS"), 67108859);
+      equal(keymask.unmask("chxQmF"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {
@@ -483,45 +483,45 @@ describe("Keymask", () => {
     });
 
     it("should mask and unmask in range 1", () => {
-      equal(keymask.mask(1), "L");
-      equal(keymask.mask(40), "W");
-      equal(keymask.unmask("L"), 1);
-      equal(keymask.unmask("W"), 40);
+      equal(keymask.mask(1), "Y");
+      equal(keymask.mask(40), "p");
+      equal(keymask.unmask("Y"), 1);
+      equal(keymask.unmask("p"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41), "Yy");
-      equal(keymask.mask(1020), "TY");
-      equal(keymask.unmask("Yy"), 41);
-      equal(keymask.unmask("TY"), 1020);
+      equal(keymask.mask(41), "cn");
+      equal(keymask.mask(1020), "Dm");
+      equal(keymask.unmask("cn"), 41);
+      equal(keymask.unmask("Dm"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021), "rgY");
-      equal(keymask.mask(65520), "nwK");
-      equal(keymask.unmask("rgY"), 1021);
-      equal(keymask.unmask("nwK"), 65520);
+      equal(keymask.mask(1021), "GHD");
+      equal(keymask.mask(65520), "MZQ");
+      equal(keymask.unmask("GHD"), 1021);
+      equal(keymask.unmask("MZQ"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521), "LwNY");
-      equal(keymask.mask(2097142), "LCNR");
-      equal(keymask.unmask("LwNY"), 65521);
-      equal(keymask.unmask("LCNR"), 2097142);
+      equal(keymask.mask(65521), "PNCh");
+      equal(keymask.mask(2097142), "PMCZ");
+      equal(keymask.unmask("PNCh"), 65521);
+      equal(keymask.unmask("PMCZ"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143), "vqWTb");
-      equal(keymask.mask(67108858), "RdXwd");
-      equal(keymask.unmask("vqWTb"), 2097143);
-      equal(keymask.unmask("RdXwd"), 67108858);
+      equal(keymask.mask(2097143), "SgMZp");
+      equal(keymask.mask(67108858), "WjTVg");
+      equal(keymask.unmask("SgMZp"), 2097143);
+      equal(keymask.unmask("WjTVg"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859), "sGjCvV");
-      equal(keymask.mask(4294967290), "MkBcjm");
-      equal(keymask.unmask("sGjCvV"), 67108859);
-      equal(keymask.unmask("MkBcjm"), 4294967290);
+      equal(keymask.mask(67108859), "DrFGkn");
+      equal(keymask.mask(4294967290), "ysMKWp");
+      equal(keymask.unmask("DrFGkn"), 67108859);
+      equal(keymask.unmask("ysMKWp"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {

--- a/test/Keymask.test.ts
+++ b/test/Keymask.test.ts
@@ -178,9 +178,99 @@ describe("Keymask", () => {
     });
   });
 
-  describe("Defined output lengths", () => {
+  describe("Defined size (single)", () => {
     const keymask = new Keymask({
-      outputs: [5, 7, 9]
+      size: 7
+    });
+
+    it("should mask and unmask in range 1", () => {
+      equal(keymask.mask(1), "dxvpXgJ");
+      equal(keymask.mask(40), "CHfWmWG");
+      equal(keymask.unmask("dxvpXgJ"), 1);
+      equal(keymask.unmask("CHfWmWG"), 40);
+    });
+
+    it("should mask and unmask in range 2", () => {
+      equal(keymask.mask(41), "fDZLKDP");
+      equal(keymask.mask(1020), "kWRXqnP");
+      equal(keymask.unmask("fDZLKDP"), 41);
+      equal(keymask.unmask("kWRXqnP"), 1020);
+    });
+
+    it("should mask and unmask in range 3", () => {
+      equal(keymask.mask(1021), "NTMMNTX");
+      equal(keymask.mask(65520), "vvKyWTh");
+      equal(keymask.unmask("NTMMNTX"), 1021);
+      equal(keymask.unmask("vvKyWTh"), 65520);
+    });
+
+    it("should mask and unmask in range 4", () => {
+      equal(keymask.mask(65521), "KqCvfDG");
+      equal(keymask.mask(2097142), "FyMFQPC");
+      equal(keymask.unmask("KqCvfDG"), 65521);
+      equal(keymask.unmask("FyMFQPC"), 2097142);
+    });
+
+    it("should mask and unmask in range 5", () => {
+      equal(keymask.mask(2097143), "hvHtnvK");
+      equal(keymask.mask(67108858), "wpBXHgK");
+      equal(keymask.unmask("hvHtnvK"), 2097143);
+      equal(keymask.unmask("wpBXHgK"), 67108858);
+    });
+
+    it("should mask and unmask in range 6", () => {
+      equal(keymask.mask(67108859), "YmwLfMS");
+      equal(keymask.mask(4294967290), "KggKsnM");
+      equal(keymask.unmask("YmwLfMS"), 67108859);
+      equal(keymask.unmask("KggKsnM"), 4294967290);
+    });
+
+    it("should mask and unmask in range 7", () => {
+      equal(keymask.mask(4294967291), "ncbyPTV");
+      equal(keymask.mask(137438953446), "mGJFsQc");
+      equal(keymask.unmask("ncbyPTV"), 4294967291);
+      equal(keymask.unmask("mGJFsQc"), 137438953446);
+    });
+
+    it("should mask and unmask in range 8", () => {
+      equal(keymask.mask(137438953447), "vwmKZxKZ");
+      equal(keymask.mask(4398046511092), "GwdjRScK");
+      equal(keymask.unmask("vwmKZxKZ"), 137438953447);
+      equal(keymask.unmask("GwdjRScK"), 4398046511092);
+    });
+
+    it("should mask and unmask in range 9", () => {
+      equal(keymask.mask(4398046511093), "gqFHjWmxF");
+      equal(keymask.mask(281474976710596), "wZVHVzvrj");
+      equal(keymask.unmask("gqFHjWmxF"), 4398046511093);
+      equal(keymask.unmask("wZVHVzvrj"), 281474976710596);
+    });
+
+    it("should mask and unmask in range 10", () => {
+      equal(keymask.mask(281474976710597), "nWRWYwnkhD");
+      equal(keymask.mask(9007199254740880), "KdCvLBSKJb");
+      equal(keymask.unmask("nWRWYwnkhD"), 281474976710597);
+      equal(keymask.unmask("KdCvLBSKJb"), 9007199254740880);
+    });
+
+    it("should mask and unmask in range 11", () => {
+      equal(keymask.mask(9007199254740881n), "NjQkwmfKKVP");
+      equal(keymask.mask(288230376151711716n), "TQmxMJKgrNW");
+      equal(keymask.unmask("NjQkwmfKKVP"), 9007199254740881n);
+      equal(keymask.unmask("TQmxMJKgrNW"), 288230376151711716n);
+    });
+
+    it("should mask and unmask in range 12", () => {
+      equal(keymask.mask(288230376151711717n), "DjfkCZLtcBLn");
+      equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
+      equal(keymask.unmask("DjfkCZLtcBLn"), 288230376151711717n);
+      equal(keymask.unmask("YcWfgzxKYXFW"), 18446744073709551556n);
+    });
+  });
+
+  describe("Defined sizes (multiple)", () => {
+    const keymask = new Keymask({
+      size: [5, 7, 9]
     });
 
     it("should mask and unmask in range 1", () => {

--- a/util/seed.js
+++ b/util/seed.js
@@ -1,0 +1,5 @@
+import { randomBytes } from "node:crypto";
+
+console.log(randomBytes(32).toString("base64url"));
+console.log(randomBytes(24).toString("base64url"));
+console.log(randomBytes(8).toString("base64url"));

--- a/util/speedtest.js
+++ b/util/speedtest.js
@@ -27,11 +27,7 @@ if (test === "generator") {
   console.log("");
 
 } else if (test === "base41") {
-  const base41 = new Base41({
-    outputs: length,
-    pad: true,
-    prime: true
-  });
+  const base41 = new Base41();
   base41.encode(1);
 
   for (let i = 1; i <= n; i++) {
@@ -47,7 +43,7 @@ if (test === "generator") {
 
 } else if (test === "keymask") {
   const keymask = new Keymask({
-    outputs: length
+    size: length
   });
   keymask.mask(1);
 


### PR DESCRIPTION
- Update generator seeds (breaking change)
- Remove unnecessary options (`prime`, `pad`) from the `Base41` class. Remove `binaryLimits`.
- Move `encodingLength()` to the `Keymask` module
- Refactor `Base41` encoding blocks
- Add support for reusable encoder
- Update README
- Bump version to 0.3.0