### PR TITLE
Use DataView when unpacking seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Base41 encoding scheme.
 ```
 
 The Keymask instance can be personalized using a 256-bit seed value. As long as
-you keep this value secret, it will be extremely difficult for anyone who
+this value is kept secret, it will be extremely difficult for anyone who
 doesn't know the seed to reverse map the encoded values.
 
 ## Motivation
@@ -43,11 +43,11 @@ characters. It can therefore be said that Base41 is 25% more efficient than
 hexadecimal and 40% more efficient than decimal, but 20% *less* efficient than
 Base85.)
 
-The primary advantage that Base41 holds over Base85 is that it is free of any
-special characters, which makes it suitable for use in URLs or other places
-where non-alphanumeric characters have special meanings or functions. Base85 is
-more compact, but its output will sometimes need to be further encoded or
-escaped. Base85 encodings are also more difficult to communicate verbally.
+The primary advantage that Base41 holds over Base85 is that it is free of
+special characters, which makes it suitable for use in URLs or anywhere else
+that non-alphanumeric characters have special meanings or functions. Base85 is
+more compact, but its output needs to be further encoded or escaped in such
+settings, which negates its main benefit.
 
 For its part, Base57 (or the somewhat more common Base58) is also free of
 special characters, therefore URL-safe. However, since it includes virtually
@@ -77,7 +77,7 @@ all you need, as it provides a unified interface to the other two.
 The `Keymask` class constructor can be passed an object containing various
 optional settings, as outlined in the following sections. The default
 constructor will create an instance that encodes variable-length outputs (the
-output length will depend on the magnitude of the input value), while decoded
+output length will depend on the magnitude of the input value), and decoded
 values will be returned as either a `number` or a `bigint`, depending again on
 the magnitude of the value.
 
@@ -123,7 +123,7 @@ encoder itself requires `24` bytes.)
 
 Providing a randomized `seed` is highly recommended, as this makes the mappings
 between inputs and outputs extremely difficult to predict (unless you know the
-`seed`). If possible, the `seed` should be kept secret, but it should generally
+`seed`). If possible, the `seed` should be kept secret, and it should generally
 not change for the lifetime of your application (doing so would make it
 impossible to unmask previously masked values).
 
@@ -147,9 +147,9 @@ const unmasked = keymask.unmask(masked); // 123456789
 ### `size`
 
 The output length(s) can be explicitly defined by providing a number or an
-array of numbers to the `size` option. If this is a single number, it defines
-the *minimum* output length; values that exceed this minimum length will scale
-automatically, with additional characters added as needed.
+array of numbers to the `size` option. If a single number is provided, it will
+define the *minimum* output length; values that exceed this minimum length will
+scale automatically, with additional characters added as needed.
 
 If an array of numbers is provided, they represent successive allowable output
 lengths. If the highest provided `size` is less than `12`, then longer outputs
@@ -199,14 +199,15 @@ const unmasked = keymask.unmask(masked); // 123456789n
 
 It is not uncommon for an application to employ multiple serial numbers (for
 example, multiple database tables with auto-incrementing primary keys). In such
-cases, it may be desirable to have them each map to a unique keymask sequence.
+cases, it may be desirable to have each of them map to a unique keymask
+sequence.
 
-One option is to simply instantiate multiple `Keymask` instances, each with a
+One way of doing this is to create multiple `Keymask` instances, each with a
 unique 256-bit seed. A more efficient alternative is to have all of the
 instances share a single `Base41` encoder. The encoder can be seeded once
-(requires a 192-bit seed) and passed into each `Keymask` instance. As a result,
-each instance only requires an additional 64-bit seed to customize the LCG
-sequence.
+(requires a 192-bit seed) and passed into each `Keymask` instance. In
+consequence, each instance only requires an additional 64-bit (8-byte) seed
+to customize the LCG sequence.
 
 **Example (Multiple instances with a shared encoder)**
 
@@ -242,10 +243,10 @@ const mask2c = keymask2.mask(3); // "xmXrp"
 ## Performance
 
 On commodity hardware (2020 M1 Macbook Air), a single invocation of
-`Keymask.mask()` (JIT-compiled) takes on the order of 20 microseconds, whereas
-a tight loop of one million invocations takes an average of between 0.2 and 0.7
-microseconds per call, depending on the output length. This amounts to over a
-million keymasks per second.
+`Keymask.mask()` (JIT-compiled) takes on the order of 10 microseconds, whereas
+a tight loop of one million invocations takes an average of between 0.2 and 0.6
+microseconds per call (depending on the output length). This amounts to well
+over a million keymasks per second.
 
 For best performance, the `Keymask` class instance should be cached for
 repeated usage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymask-base41",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Map sequential IDs or serial numbers to random-looking Base41-encoded strings",
   "type": "module",
   "exports": {
@@ -27,9 +27,6 @@
   },
   "keywords": [
     "LCG",
-    "linear",
-    "congruential",
-    "generator",
     "linear congruential generator",
     "base41",
     "string",

--- a/src/Base41.ts
+++ b/src/Base41.ts
@@ -16,30 +16,24 @@ const factors: number[] = [
 
 function shuffleAlphabet(seed?: ArrayBufferLike): string[] {
   const chars = alphabet.slice(0);
-
   if (seed) {
     const source = new DataView(seed);
-    const values = Array.from({ length: 6 }, (_, i) => source.getUint32(i * 4, true));
     let mod = 41;
-    let range: number;
-    let bits: number;
+    let value: number;
     let n: number;
     let swap: string;
-    values.forEach((value, i) => {
-      range = factors[i];
-      bits = value % range;
-
+    factors.forEach((range, i) => {
+      value = source.getUint32(i * 4, true) % range;
       while (range > 1) {
         range /= mod--;
-        n = Math.floor(bits / range);
-        bits %= range;
+        n = Math.floor(value / range);
+        value %= range;
         swap = chars[n];
         chars[n] = chars[mod];
         chars[mod] = swap;
       }
     });
   }
-
   return chars;
 }
 

--- a/src/Base41.ts
+++ b/src/Base41.ts
@@ -6,24 +6,20 @@ const alphabet: string[] = [
 ];
 
 const factors: number[] = [
-  0x380fb34cb80, // 41*40*39*38*37*36*35*34
-  0x082573a0a00, // 33*32*31*30*29*28*27*26
-  0xac9c3006800, // 25*24*23*22*21*20*19*18*17*16
-  0x13077775800  // 15!
+  0x055c3050, // 41*40*39*38*37
+  0x02b24b00, // 36*35*34*33*32
+  0x1f990650, // 31*30*29*28*27*26
+  0x0799adc0, // 25*24*23*22*21*20
+  0x0f230dc0, // 19*18*17*16*15*14*13
+  0x1c8cfc00  // 12*11*10*9*8*7*6*5*4*3*2*1
 ];
 
 function shuffleAlphabet(seed?: ArrayBufferLike): string[] {
   const chars = alphabet.slice(0);
 
   if (seed) {
-    const source = new Uint32Array(seed);
-    const values = [
-      source[0] * (source[1] & 0xffff),
-      source[2] * (source[1] >>> 16),
-      source[3] * (source[4] & 0xffff),
-      source[5] * (source[4] >>> 16)
-    ];
-
+    const source = new DataView(seed);
+    const values = Array.from({ length: 6 }, (_, i) => source.getUint32(i * 4, true));
     let mod = 41;
     let range: number;
     let bits: number;
@@ -47,42 +43,22 @@ function shuffleAlphabet(seed?: ArrayBufferLike): string[] {
   return chars;
 }
 
-function restoreNumber(raw: Uint8Array): number {
-  let i = raw.length - 1;
-  let n = raw[i--];
-  while (i >= 0) {
-    n *= 41;
-    n += raw[i--];
-  }
-  return n;
-}
-
-function restoreBigInt(raw: Uint8Array): bigint {
-  let i = raw.length - 1;
-  let n = BigInt(raw[i--]);
-  while (i >= 0) {
-    n *= 41n;
-    n += BigInt(raw[i--]);
-  }
-  return n;
-}
-
 export class Base41 {
   private chars: string[];
 
   constructor(seed?: ArrayBufferLike | ArrayBufferView) {
+    if (ArrayBuffer.isView(seed)) {
+      seed = seed.buffer;
+    }
     if (seed && seed.byteLength !== 24) {
       const seedBuffer = new ArrayBuffer(24);
-      if (ArrayBuffer.isView(seed)) {
-        seed = seed.buffer;
-      }
       new Uint8Array(seedBuffer).set(new Uint8Array(seed.slice(0, 24)));
       seed = seedBuffer;
     }
-    this.chars = shuffleAlphabet(ArrayBuffer.isView(seed) ? seed.buffer : seed);
+    this.chars = shuffleAlphabet(seed);
   }
 
-  private encodeValue(value: number | bigint, length: number): string {
+  encode(value: number | bigint, length: number): string {
     let n: number;
     let result = "";
 
@@ -105,63 +81,31 @@ export class Base41 {
     return result;
   }
 
-  encode(value: number | bigint | ArrayBufferLike | ArrayBufferView, length: number): string {
-    let result = "";
-
-    if (typeof value === "object") {
-      if (ArrayBuffer.isView(value)) {
-        value = value.buffer;
-      }
-
-      const blocks = new BigUint64Array(Math.ceil(value.byteLength / 8));
-      new Uint8Array(blocks.buffer).set(new Uint8Array(value));
-
-      const last = blocks.length - 1;
-      blocks.forEach((block, index) => {
-        result += this.encodeValue(
-          block,
-          index === last ? length : 12,
-        );
-      });
-
-    } else {
-      result = this.encodeValue(value, length);
-    }
-
-    return result;
-  }
-
-  private decodeValue(value: string, bigint: boolean = false): number | bigint {
+  decode(value: string): number | bigint {
     const raw = new Uint8Array(value.length);
 
     for (let i = 0; i < raw.length; i++) {
       raw[i] = this.chars.indexOf(value.charAt(i));
     }
 
-    if (bigint) {
-      return restoreBigInt(raw);
-    }
+    let i = raw.length - 1;
+    let n: number | bigint;
 
     if (value.length < 11) {
-      return restoreNumber(raw);
+      n = raw[i--];
+      while (i >= 0) {
+        n *= 41;
+        n += raw[i--];
+      }
+
+    } else {
+      n = BigInt(raw[i--]);
+      while (i >= 0) {
+        n *= 41n;
+        n += BigInt(raw[i--]);
+      }
     }
 
-    const b = restoreBigInt(raw);
-    const n = Number(b);
-    return n > Number.MAX_SAFE_INTEGER ? b : n;
-  }
-
-  decode(value: string): number | bigint | ArrayBufferLike {
-    if (value.length <= 12) {
-      return this.decodeValue(value);
-    }
-
-    const entries = Math.ceil(value.length / 12);
-    const result = new BigUint64Array(entries);
-    for (let i = 0; i < entries; i++) {
-      result[i] = this.decodeValue(value.slice(i * 12, (i + 1) * 12), true) as bigint;
-    }
-
-    return result.buffer;
+    return n;
   }
 }

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -31,10 +31,9 @@ export class Generator {
       if (ArrayBuffer.isView(seed)) {
         seed = seed.buffer;
       }
-      seed = seed.slice(0, 8);
-      const a32 = new Uint32Array(seed);
-      const n32 = a32[0] ^ a32[1];
-      const n64 = new BigUint64Array(seed)[0];
+      const data = new DataView(seed.slice(0, 8));
+      const n32 = data.getUint32(0, true) ^ data.getUint32(4, true);
+      const n64 = data.getBigUint64(0, true);
       this.offsets[1] = n32 % 40;
       this.offsets[2] = n32 % 1020;
       this.offsets[3] = n32 % 65520;

--- a/src/Keymask.ts
+++ b/src/Keymask.ts
@@ -90,6 +90,6 @@ export class Keymask {
 
   unmask(value: string): number | bigint {
     const n = this.base41.decode(value);
-    return this.generator.previous(n as (number | bigint), value.length);
+    return this.generator.previous(n, value.length);
   }
 }

--- a/src/Keymask.ts
+++ b/src/Keymask.ts
@@ -1,4 +1,5 @@
-import { Base41, Generator } from "./index";
+import { Base41 } from "./Base41";
+import { Generator } from "./Generator";
 
 const limits: bigint[] = [
   0n,

--- a/test/Base41.test.ts
+++ b/test/Base41.test.ts
@@ -1,4 +1,4 @@
-import { equal, deepEqual } from "node:assert/strict";
+import { equal } from "node:assert/strict";
 import { Base41 } from "../src/";
 
 describe("Base41", () => {
@@ -23,138 +23,92 @@ describe("Base41", () => {
   describe("Unseeded", () => {
     const base41 = new Base41();
 
-    describe("Single value", () => {
-      it("should handle 1-character encodings", () => {
-        equal(base41.encode(1, 1), "C");
-        equal(base41.encode(1, 2), "CB");
-        equal(base41.encode(40, 1), "z");
-        equal(base41.encode(40, 2), "zB");
-        equal(base41.decode("C"), 1);
-        equal(base41.decode("CB"), 1);
-        equal(base41.decode("z"), 40);
-        equal(base41.decode("zB"), 40);
-      });
-
-      it("should handle 2-character encodings", () => {
-        equal(base41.encode(41, 2), "BC");
-        equal(base41.encode(1020, 2), "vf");
-        equal(base41.decode("BC"), 41);
-        equal(base41.decode("vf"), 1020);
-      });
-
-      it("should handle 3-character encodings", () => {
-        equal(base41.encode(1021, 3), "wfB");
-        equal(base41.encode(65520, 3), "Dzx");
-        equal(base41.decode("wfB"), 1021);
-        equal(base41.decode("Dzx"), 65520);
-      });
-
-      it("should handle 4-character encodings", () => {
-        equal(base41.encode(65521, 4), "FzxB");
-        equal(base41.encode(2097142, 4), "rcWn");
-        equal(base41.decode("FzxB"), 65521);
-        equal(base41.decode("rcWn"), 2097142);
-      });
-
-      it("should handle 5-character encodings", () => {
-        equal(base41.encode(2097143, 5), "scWnB");
-        equal(base41.encode(67108858, 5), "Wzknd");
-        equal(base41.decode("scWnB"), 2097143);
-        equal(base41.decode("Wzknd"), 67108858);
-      });
-
-      it("should handle 6-character encodings", () => {
-        equal(base41.encode(67108859, 6), "XzkndB");
-        equal(base41.encode(4294967290, 6), "pQNxDw");
-        equal(base41.decode("XzkndB"), 67108859);
-        equal(base41.decode("pQNxDw"), 4294967290);
-      });
-
-      it("should handle 7-character encodings", () => {
-        equal(base41.encode(4294967291, 7), "qQNxDwB");
-        equal(base41.encode(137438953446, 7), "NDDtPxk");
-        equal(base41.decode("qQNxDwB"), 4294967291);
-        equal(base41.decode("NDDtPxk"), 137438953446);
-      });
-
-      it("should handle 8-character encodings", () => {
-        equal(base41.encode(137438953447, 8), "PDDtPxkB");
-        equal(base41.encode(4398046511092, 8), "rMgSNvdc");
-        equal(base41.decode("PDDtPxkB"), 137438953447);
-        equal(base41.decode("rMgSNvdc"), 4398046511092);
-      });
-
-      it("should handle 9-character encodings", () => {
-        equal(base41.encode(4398046511093, 9), "sMgSNvdcB");
-        equal(base41.encode(281474976710596, 9), "qmVrJfPNt");
-        equal(base41.decode("sMgSNvdcB"), 4398046511093);
-        equal(base41.decode("qmVrJfPNt"), 281474976710596);
-      });
-
-      it("should handle 10-character encodings", () => {
-        equal(base41.encode(281474976710597, 10), "rmVrJfPNtB");
-        equal(base41.encode(9007199254740880, 10), "FRFFRtCCbj");
-        equal(base41.decode("rmVrJfPNtB"), 281474976710597);
-        equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
-      });
-
-      it("should handle 11-character encodings", () => {
-        equal(base41.encode(9007199254740881, 11), "GRFFRtCCbjB");
-        equal(base41.encode(288230376151711716n, 11), "FRhVLdXrVYb");
-        equal(base41.decode("GRFFRtCCbjB"), 9007199254740881);
-        equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
-      });
-
-      it("should handle 12-character encodings", () => {
-        equal(base41.encode(288230376151711717n, 12), "GRhVLdXrVYbB");
-        equal(base41.encode(18446744073709551556n, 12), "xWGzGMzLNQbr");
-        equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
-        equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
-      });
+    it("should handle 1-character encodings", () => {
+      equal(base41.encode(1, 1), "C");
+      equal(base41.encode(1, 2), "CB");
+      equal(base41.encode(40, 1), "z");
+      equal(base41.encode(40, 2), "zB");
+      equal(base41.decode("C"), 1);
+      equal(base41.decode("CB"), 1);
+      equal(base41.decode("z"), 40);
+      equal(base41.decode("zB"), 40);
     });
 
-    describe("Multiple values", () => {
-      it("should handle 1-character encodings", () => {
-        equal(base41.encode(new BigUint64Array([1n, 1n]), 1), "CBBBBBBBBBBBC");
-        equal(base41.encode(new BigUint64Array([40n, 40n]), 1), "zBBBBBBBBBBBz");
-        deepEqual(base41.decode("CBBBBBBBBBBBC"), new BigUint64Array([1n, 1n]).buffer);
-        deepEqual(base41.decode("zBBBBBBBBBBBz"), new BigUint64Array([40n, 40n]).buffer);
-      });
+    it("should handle 2-character encodings", () => {
+      equal(base41.encode(41, 2), "BC");
+      equal(base41.encode(1020, 2), "vf");
+      equal(base41.decode("BC"), 41);
+      equal(base41.decode("vf"), 1020);
+    });
 
-      it("should handle 2-character encodings", () => {
-        equal(base41.encode(new BigUint64Array([41n, 41n]), 2), "BCBBBBBBBBBBBC");
-        equal(base41.encode(new BigUint64Array([1020n, 1020n]), 2), "vfBBBBBBBBBBvf");
-        deepEqual(base41.decode("BCBBBBBBBBBBBC"), new BigUint64Array([41n, 41n]).buffer);
-        deepEqual(base41.decode("vfBBBBBBBBBBvf"), new BigUint64Array([1020n, 1020n]).buffer);
-      });
+    it("should handle 3-character encodings", () => {
+      equal(base41.encode(1021, 3), "wfB");
+      equal(base41.encode(65520, 3), "Dzx");
+      equal(base41.decode("wfB"), 1021);
+      equal(base41.decode("Dzx"), 65520);
+    });
 
-      it("should handle 3-character encodings", () => {
-        equal(base41.encode(new BigUint64Array([1021n, 1021n]), 3), "wfBBBBBBBBBBwfB");
-        equal(base41.encode(new BigUint64Array([65520n, 65520n]), 3), "DzxBBBBBBBBBDzx");
-        deepEqual(base41.decode("wfBBBBBBBBBBwfB"), new BigUint64Array([1021n, 1021n]).buffer);
-        deepEqual(base41.decode("DzxBBBBBBBBBDzx"), new BigUint64Array([65520n, 65520n]).buffer);
-      });
+    it("should handle 4-character encodings", () => {
+      equal(base41.encode(65521, 4), "FzxB");
+      equal(base41.encode(2097142, 4), "rcWn");
+      equal(base41.decode("FzxB"), 65521);
+      equal(base41.decode("rcWn"), 2097142);
+    });
 
-      it("should handle 10-character encodings", () => {
-        equal(base41.encode(new BigUint64Array([281474976710597n, 281474976710597n]), 10), "rmVrJfPNtBBBrmVrJfPNtB");
-        equal(base41.encode(new BigUint64Array([9007199254740880n, 9007199254740880n]), 10), "FRFFRtCCbjBBFRFFRtCCbj");
-        deepEqual(base41.decode("rmVrJfPNtBBBrmVrJfPNtB"), new BigUint64Array([281474976710597n, 281474976710597n]).buffer);
-        deepEqual(base41.decode("FRFFRtCCbjBBFRFFRtCCbj"), new BigUint64Array([9007199254740880n, 9007199254740880n]).buffer);
-      });
+    it("should handle 5-character encodings", () => {
+      equal(base41.encode(2097143, 5), "scWnB");
+      equal(base41.encode(67108858, 5), "Wzknd");
+      equal(base41.decode("scWnB"), 2097143);
+      equal(base41.decode("Wzknd"), 67108858);
+    });
 
-      it("should handle 11-character encodings", () => {
-        equal(base41.encode(new BigUint64Array([9007199254740881n, 9007199254740881n]), 11), "GRFFRtCCbjBBGRFFRtCCbjB");
-        equal(base41.encode(new BigUint64Array([288230376151711716n, 288230376151711716n]), 11), "FRhVLdXrVYbBFRhVLdXrVYb");
-        deepEqual(base41.decode("GRFFRtCCbjBBGRFFRtCCbjB"), new BigUint64Array([9007199254740881n, 9007199254740881n]).buffer);
-        deepEqual(base41.decode("FRhVLdXrVYbBFRhVLdXrVYb"), new BigUint64Array([288230376151711716n, 288230376151711716n]).buffer);
-      });
+    it("should handle 6-character encodings", () => {
+      equal(base41.encode(67108859, 6), "XzkndB");
+      equal(base41.encode(4294967290, 6), "pQNxDw");
+      equal(base41.decode("XzkndB"), 67108859);
+      equal(base41.decode("pQNxDw"), 4294967290);
+    });
 
-      it("should handle 12-character encodings", () => {
-        equal(base41.encode(new BigUint64Array([288230376151711717n, 288230376151711717n]), 12), "GRhVLdXrVYbBGRhVLdXrVYbB");
-        equal(base41.encode(new BigUint64Array([18446744073709551556n, 18446744073709551556n]), 12), "xWGzGMzLNQbrxWGzGMzLNQbr");
-        deepEqual(base41.decode("GRhVLdXrVYbBGRhVLdXrVYbB"), new BigUint64Array([288230376151711717n, 288230376151711717n]).buffer);
-        deepEqual(base41.decode("xWGzGMzLNQbrxWGzGMzLNQbr"), new BigUint64Array([18446744073709551556n, 18446744073709551556n]).buffer);
-      });
+    it("should handle 7-character encodings", () => {
+      equal(base41.encode(4294967291, 7), "qQNxDwB");
+      equal(base41.encode(137438953446, 7), "NDDtPxk");
+      equal(base41.decode("qQNxDwB"), 4294967291);
+      equal(base41.decode("NDDtPxk"), 137438953446);
+    });
+
+    it("should handle 8-character encodings", () => {
+      equal(base41.encode(137438953447, 8), "PDDtPxkB");
+      equal(base41.encode(4398046511092, 8), "rMgSNvdc");
+      equal(base41.decode("PDDtPxkB"), 137438953447);
+      equal(base41.decode("rMgSNvdc"), 4398046511092);
+    });
+
+    it("should handle 9-character encodings", () => {
+      equal(base41.encode(4398046511093, 9), "sMgSNvdcB");
+      equal(base41.encode(281474976710596, 9), "qmVrJfPNt");
+      equal(base41.decode("sMgSNvdcB"), 4398046511093);
+      equal(base41.decode("qmVrJfPNt"), 281474976710596);
+    });
+
+    it("should handle 10-character encodings", () => {
+      equal(base41.encode(281474976710597, 10), "rmVrJfPNtB");
+      equal(base41.encode(9007199254740880, 10), "FRFFRtCCbj");
+      equal(base41.decode("rmVrJfPNtB"), 281474976710597);
+      equal(base41.decode("FRFFRtCCbj"), 9007199254740880);
+    });
+
+    it("should handle 11-character encodings", () => {
+      equal(base41.encode(9007199254740881n, 11), "GRFFRtCCbjB");
+      equal(base41.encode(288230376151711716n, 11), "FRhVLdXrVYb");
+      equal(base41.decode("GRFFRtCCbjB"), 9007199254740881n);
+      equal(base41.decode("FRhVLdXrVYb"), 288230376151711716n);
+    });
+
+    it("should handle 12-character encodings", () => {
+      equal(base41.encode(288230376151711717n, 12), "GRhVLdXrVYbB");
+      equal(base41.encode(18446744073709551556n, 12), "xWGzGMzLNQbr");
+      equal(base41.decode("GRhVLdXrVYbB"), 288230376151711717n);
+      equal(base41.decode("xWGzGMzLNQbr"), 18446744073709551556n);
     });
   });
 
@@ -166,92 +120,92 @@ describe("Base41", () => {
     ]));
 
     it("should handle null character encodings", () => {
-      equal(base41.encode(0, 1), "t");
-      equal(base41.decode("t"), 0);
+      equal(base41.encode(0, 1), "q");
+      equal(base41.decode("q"), 0);
     });
 
     it("should handle 1-character encodings", () => {
-      equal(base41.encode(1, 1), "F");
-      equal(base41.encode(40, 1), "C");
-      equal(base41.decode("F"), 1);
-      equal(base41.decode("C"), 40);
+      equal(base41.encode(1, 1), "d");
+      equal(base41.encode(40, 1), "n");
+      equal(base41.decode("d"), 1);
+      equal(base41.decode("n"), 40);
     });
 
     it("should handle 2-character encodings", () => {
-      equal(base41.encode(41, 2), "tF");
-      equal(base41.encode(1020, 2), "MD");
-      equal(base41.decode("tF"), 41);
-      equal(base41.decode("MD"), 1020);
+      equal(base41.encode(41, 2), "qd");
+      equal(base41.encode(1020, 2), "gr");
+      equal(base41.decode("qd"), 41);
+      equal(base41.decode("gr"), 1020);
     });
 
     it("should handle 3-character encodings", () => {
-      equal(base41.encode(1021, 3), "vDt");
-      equal(base41.encode(65520, 3), "VCH");
-      equal(base41.decode("vDt"), 1021);
-      equal(base41.decode("VCH"), 65520);
+      equal(base41.encode(1021, 3), "Zrq");
+      equal(base41.encode(65520, 3), "ynW");
+      equal(base41.decode("Zrq"), 1021);
+      equal(base41.decode("ynW"), 65520);
     });
 
     it("should handle 4-character encodings", () => {
-      equal(base41.encode(65521, 4), "XCHt");
-      equal(base41.encode(2097142, 4), "gBWK");
-      equal(base41.decode("XCHt"), 65521);
-      equal(base41.decode("gBWK"), 2097142);
+      equal(base41.encode(65521, 4), "SnWq");
+      equal(base41.encode(2097142, 4), "DxwP");
+      equal(base41.decode("SnWq"), 65521);
+      equal(base41.decode("DxwP"), 2097142);
     });
 
     it("should handle 5-character encodings", () => {
-      equal(base41.encode(2097143, 5), "ZBWKt");
-      equal(base41.encode(67108858, 5), "WCjKp");
-      equal(base41.decode("ZBWKt"), 2097143);
-      equal(base41.decode("WCjKp"), 67108858);
+      equal(base41.encode(2097143, 5), "JxwPq");
+      equal(base41.encode(67108858, 5), "wnRPY");
+      equal(base41.decode("JxwPq"), 2097143);
+      equal(base41.decode("wnRPY"), 67108858);
     });
 
     it("should handle 6-character encodings", () => {
-      equal(base41.encode(67108859, 6), "wCjKpt");
-      equal(base41.encode(4294967290, 6), "TnxHVv");
-      equal(base41.decode("wCjKpt"), 67108859);
-      equal(base41.decode("TnxHVv"), 4294967290);
+      equal(base41.encode(67108859, 6), "snRPYq");
+      equal(base41.encode(4294967290, 6), "HhvWyZ");
+      equal(base41.decode("snRPYq"), 67108859);
+      equal(base41.decode("HhvWyZ"), 4294967290);
     });
 
     it("should handle 7-character encodings", () => {
-      equal(base41.encode(4294967291, 7), "fnxHVvt");
-      equal(base41.encode(137438953446, 7), "xVVNrHj");
-      equal(base41.decode("fnxHVvt"), 4294967291);
-      equal(base41.decode("xVVNrHj"), 137438953446);
+      equal(base41.encode(4294967291, 7), "BhvWyZq");
+      equal(base41.encode(137438953446, 7), "vyytNWR");
+      equal(base41.decode("BhvWyZq"), 4294967291);
+      equal(base41.decode("vyytNWR"), 137438953446);
     });
 
     it("should handle 8-character encodings", () => {
-      equal(base41.encode(137438953447, 8), "rVVNrHjt");
-      equal(base41.encode(4398046511092, 8), "ghzkxMpB");
-      equal(base41.decode("rVVNrHjt"), 137438953447);
-      equal(base41.decode("ghzkxMpB"), 4398046511092);
+      equal(base41.encode(137438953447, 8), "NyytNWRq");
+      equal(base41.encode(4398046511092, 8), "DcCQvgYx");
+      equal(base41.decode("NyytNWRq"), 137438953447);
+      equal(base41.decode("DcCQvgYx"), 4398046511092);
     });
 
     it("should handle 9-character encodings", () => {
-      equal(base41.encode(4398046511093, 9), "ZhzkxMpBt");
-      equal(base41.encode(281474976710596, 9), "fQJgbDrxN");
-      equal(base41.decode("ZhzkxMpBt"), 4398046511093);
-      equal(base41.decode("fQJgbDrxN"), 281474976710596);
+      equal(base41.encode(4398046511093, 9), "JcCQvgYxq");
+      equal(base41.encode(281474976710596, 9), "BfMDGrNvt");
+      equal(base41.decode("JcCQvgYxq"), 4398046511093);
+      equal(base41.decode("BfMDGrNvt"), 281474976710596);
     });
 
     it("should handle 10-character encodings", () => {
-      equal(base41.encode(281474976710597, 10), "gQJgbDrxNt");
-      equal(base41.encode(9007199254740880, 10), "XPXXPNFFds");
-      equal(base41.decode("gQJgbDrxNt"), 281474976710597);
-      equal(base41.decode("XPXXPNFFds"), 9007199254740880);
+      equal(base41.encode(281474976710597, 10), "DfMDGrNvtq");
+      equal(base41.encode(9007199254740880, 10), "SmSSmtddpL");
+      equal(base41.decode("DfMDGrNvtq"), 281474976710597);
+      equal(base41.decode("SmSSmtddpL"), 9007199254740880);
     });
 
     it("should handle 11-character encodings", () => {
-      equal(base41.encode(9007199254740881, 11), "cPXXPNFFdst");
-      equal(base41.encode(288230376151711716n, 11), "XPYJypwgJqd");
-      equal(base41.decode("cPXXPNFFdst"), 9007199254740881);
-      equal(base41.decode("XPYJypwgJqd"), 288230376151711716n);
+      equal(base41.encode(9007199254740881n, 11), "zmSSmtddpLq");
+      equal(base41.encode(288230376151711716n, 11), "SmVMXYsDMkp");
+      equal(base41.decode("zmSSmtddpLq"), 9007199254740881n);
+      equal(base41.decode("SmVMXYsDMkp"), 288230376151711716n);
     });
 
     it("should handle 12-character encodings", () => {
-      equal(base41.encode(288230376151711717n, 12), "cPYJypwgJqdt");
-      equal(base41.encode(18446744073709551556n, 12), "HWcCchCyxndg");
-      equal(base41.decode("cPYJypwgJqdt"), 288230376151711717n);
-      equal(base41.decode("HWcCchCyxndg"), 18446744073709551556n);
+      equal(base41.encode(288230376151711717n, 12), "zmVMXYsDMkpq");
+      equal(base41.encode(18446744073709551556n, 12), "WwznzcnXvhpD");
+      equal(base41.decode("zmVMXYsDMkpq"), 288230376151711717n);
+      equal(base41.decode("WwznzcnXvhpD"), 18446744073709551556n);
     });
   });
 });

--- a/test/Keymask.test.ts
+++ b/test/Keymask.test.ts
@@ -384,86 +384,86 @@ describe("Keymask", () => {
 
     it("should mask and unmask in range 1", () => {
       equal(keymask.mask(1), "m");
-      equal(keymask.mask(40), "M");
+      equal(keymask.mask(40), "r");
       equal(keymask.unmask("m"), 1);
-      equal(keymask.unmask("M"), 40);
+      equal(keymask.unmask("r"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41), "Sb");
-      equal(keymask.mask(1020), "JV");
-      equal(keymask.unmask("Sb"), 41);
-      equal(keymask.unmask("JV"), 1020);
+      equal(keymask.mask(41), "Kq");
+      equal(keymask.mask(1020), "wW");
+      equal(keymask.unmask("Kq"), 41);
+      equal(keymask.unmask("wW"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021), "XCt");
-      equal(keymask.mask(65520), "rpv");
-      equal(keymask.unmask("XCt"), 1021);
-      equal(keymask.unmask("rpv"), 65520);
+      equal(keymask.mask(1021), "ZQJ");
+      equal(keymask.mask(65520), "PGR");
+      equal(keymask.unmask("ZQJ"), 1021);
+      equal(keymask.unmask("PGR"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521), "dCrv");
-      equal(keymask.mask(2097142), "dhrH");
-      equal(keymask.unmask("dCrv"), 65521);
-      equal(keymask.unmask("dhrH"), 2097142);
+      equal(keymask.mask(65521), "XQPR");
+      equal(keymask.mask(2097142), "XNPv");
+      equal(keymask.unmask("XQPR"), 65521);
+      equal(keymask.unmask("XNPv"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143), "qKnHS");
-      equal(keymask.mask(67108858), "gmFtM");
-      equal(keymask.unmask("qKnHS"), 2097143);
-      equal(keymask.unmask("gmFtM"), 67108858);
+      equal(keymask.mask(2097143), "LphvK");
+      equal(keymask.mask(67108858), "MmDJr");
+      equal(keymask.unmask("LphvK"), 2097143);
+      equal(keymask.unmask("MmDJr"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859), "CdBTKp");
-      equal(keymask.mask(4294967290), "HDnqhS");
-      equal(keymask.unmask("CdBTKp"), 67108859);
-      equal(keymask.unmask("HDnqhS"), 4294967290);
+      equal(keymask.mask(67108859), "QXFspG");
+      equal(keymask.mask(4294967290), "vThLNK");
+      equal(keymask.unmask("QXFspG"), 67108859);
+      equal(keymask.unmask("vThLNK"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {
-      equal(keymask.mask(4294967291), "QZtmmXn");
-      equal(keymask.mask(137438953446), "VSGJSdj");
-      equal(keymask.unmask("QZtmmXn"), 4294967291);
-      equal(keymask.unmask("VSGJSdj"), 137438953446);
+      equal(keymask.mask(4294967291), "nHJmmZh");
+      equal(keymask.mask(137438953446), "WKkwKXc");
+      equal(keymask.unmask("nHJmmZh"), 4294967291);
+      equal(keymask.unmask("WKkwKXc"), 137438953446);
     });
 
     it("should mask and unmask in range 8", () => {
-      equal(keymask.mask(137438953447), "jmFYpmhb");
-      equal(keymask.mask(4398046511092), "ZZycWTFS");
-      equal(keymask.unmask("jmFYpmhb"), 137438953447);
-      equal(keymask.unmask("ZZycWTFS"), 4398046511092);
+      equal(keymask.mask(137438953447), "cmDdGmNq");
+      equal(keymask.mask(4398046511092), "HHVtfsDK");
+      equal(keymask.unmask("cmDdGmNq"), 137438953447);
+      equal(keymask.unmask("HHVtfsDK"), 4398046511092);
     });
 
     it("should mask and unmask in range 9", () => {
-      equal(keymask.mask(4398046511093), "JjtTDrHJj");
-      equal(keymask.mask(281474976710596), "njnnsnMCB");
-      equal(keymask.unmask("JjtTDrHJj"), 4398046511093);
-      equal(keymask.unmask("njnnsnMCB"), 281474976710596);
+      equal(keymask.mask(4398046511093), "wcJsTPvwc");
+      equal(keymask.mask(281474976710596), "hchhyhrQF");
+      equal(keymask.unmask("wcJsTPvwc"), 4398046511093);
+      equal(keymask.unmask("hchhyhrQF"), 281474976710596);
     });
 
     it("should mask and unmask in range 10", () => {
-      equal(keymask.mask(281474976710597), "XnqngTcYVt");
-      equal(keymask.mask(9007199254740880), "rkjmnWqPVB");
-      equal(keymask.unmask("XnqngTcYVt"), 281474976710597);
-      equal(keymask.unmask("rkjmnWqPVB"), 9007199254740880);
+      equal(keymask.mask(281474976710597), "ZhLhMstdWJ");
+      equal(keymask.mask(9007199254740880), "PYcmhfLbWF");
+      equal(keymask.unmask("ZhLhMstdWJ"), 281474976710597);
+      equal(keymask.unmask("PYcmhfLbWF"), 9007199254740880);
     });
 
     it("should mask and unmask in range 11", () => {
-      equal(keymask.mask(9007199254740881n), "ZFPTtQhkBHr");
-      equal(keymask.mask(288230376151711716n), "JqfWVBjDqDz");
-      equal(keymask.unmask("ZFPTtQhkBHr"), 9007199254740881n);
-      equal(keymask.unmask("JqfWVBjDqDz"), 288230376151711716n);
+      equal(keymask.mask(9007199254740881n), "HDbsJnNYFvP");
+      equal(keymask.mask(288230376151711716n), "wLxfWFcTLTB");
+      equal(keymask.unmask("HDbsJnNYFvP"), 9007199254740881n);
+      equal(keymask.unmask("wLxfWFcTLTB"), 288230376151711716n);
     });
 
     it("should mask and unmask in range 12", () => {
-      equal(keymask.mask(288230376151711717n), "NjdfHBwHxXHr");
-      equal(keymask.mask(18446744073709551556n), "CJqbCdHcTmkY");
-      equal(keymask.unmask("NjdfHBwHxXHr"), 288230376151711717n);
-      equal(keymask.unmask("CJqbCdHcTmkY"), 18446744073709551556n);
+      equal(keymask.mask(288230376151711717n), "zcXxvFjvCZvP");
+      equal(keymask.mask(18446744073709551556n), "QwLqQXvtsmYd");
+      equal(keymask.unmask("zcXxvFjvCZvP"), 288230376151711717n);
+      equal(keymask.unmask("QwLqQXvtsmYd"), 18446744073709551556n);
     });
   });
 
@@ -478,86 +478,86 @@ describe("Keymask", () => {
 
     it("should mask and unmask in range 1", () => {
       equal(keymask.mask(1), "m");
-      equal(keymask.mask(40), "M");
+      equal(keymask.mask(40), "r");
       equal(keymask.unmask("m"), 1);
-      equal(keymask.unmask("M"), 40);
+      equal(keymask.unmask("r"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41), "Cr");
-      equal(keymask.mask(1020), "Lv");
-      equal(keymask.unmask("Cr"), 41);
-      equal(keymask.unmask("Lv"), 1020);
+      equal(keymask.mask(41), "QP");
+      equal(keymask.mask(1020), "gR");
+      equal(keymask.unmask("QP"), 41);
+      equal(keymask.unmask("gR"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021), "WVm");
-      equal(keymask.mask(65520), "HJq");
-      equal(keymask.unmask("WVm"), 1021);
-      equal(keymask.unmask("HJq"), 65520);
+      equal(keymask.mask(1021), "fWm");
+      equal(keymask.mask(65520), "vwL");
+      equal(keymask.unmask("fWm"), 1021);
+      equal(keymask.unmask("vwL"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521), "tmCW");
-      equal(keymask.mask(2097142), "tkCb");
-      equal(keymask.unmask("tmCW"), 65521);
-      equal(keymask.unmask("tkCb"), 2097142);
+      equal(keymask.mask(65521), "JmQf");
+      equal(keymask.mask(2097142), "JYQq");
+      equal(keymask.unmask("JmQf"), 65521);
+      equal(keymask.unmask("JYQq"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143), "ZDPnB");
-      equal(keymask.mask(67108858), "HgsLv");
-      equal(keymask.unmask("ZDPnB"), 2097143);
-      equal(keymask.unmask("HgsLv"), 67108858);
+      equal(keymask.mask(2097143), "HTbhF");
+      equal(keymask.mask(67108858), "vMygR");
+      equal(keymask.unmask("HTbhF"), 2097143);
+      equal(keymask.unmask("vMygR"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859), "DqBsGX");
-      equal(keymask.mask(4294967290), "hpngpH");
-      equal(keymask.unmask("DqBsGX"), 67108859);
-      equal(keymask.unmask("hpngpH"), 4294967290);
+      equal(keymask.mask(67108859), "TLFykZ");
+      equal(keymask.mask(4294967290), "NGhMGv");
+      equal(keymask.unmask("TLFykZ"), 67108859);
+      equal(keymask.unmask("NGhMGv"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {
-      equal(keymask.mask(4294967291), "gmZTCbv");
-      equal(keymask.mask(137438953446), "hPnSLjm");
-      equal(keymask.unmask("gmZTCbv"), 4294967291);
-      equal(keymask.unmask("hPnSLjm"), 137438953446);
+      equal(keymask.mask(4294967291), "MmHsQqR");
+      equal(keymask.mask(137438953446), "NbhKgcm");
+      equal(keymask.unmask("MmHsQqR"), 4294967291);
+      equal(keymask.unmask("NbhKgcm"), 137438953446);
     });
 
     it("should mask and unmask in range 8", () => {
-      equal(keymask.mask(137438953447), "GyhrfNrf");
-      equal(keymask.mask(4398046511092), "PyHYzpmr");
-      equal(keymask.unmask("GyhrfNrf"), 137438953447);
-      equal(keymask.unmask("PyHYzpmr"), 4398046511092);
+      equal(keymask.mask(137438953447), "kVNPxzPx");
+      equal(keymask.mask(4398046511092), "bVvdBGmP");
+      equal(keymask.unmask("kVNPxzPx"), 137438953447);
+      equal(keymask.unmask("bVvdBGmP"), 4398046511092);
     });
 
     it("should mask and unmask in range 9", () => {
-      equal(keymask.mask(4398046511093), "QxScYDhNS");
-      equal(keymask.mask(281474976710596), "yfvcvkGXY");
-      equal(keymask.unmask("QxScYDhNS"), 4398046511093);
-      equal(keymask.unmask("yfvcvkGXY"), 281474976710596);
+      equal(keymask.mask(4398046511093), "nCKtdTNzK");
+      equal(keymask.mask(281474976710596), "VxRtRYkZd");
+      equal(keymask.unmask("nCKtdTNzK"), 4398046511093);
+      equal(keymask.unmask("VxRtRYkZd"), 281474976710596);
     });
 
     it("should mask and unmask in range 10", () => {
-      equal(keymask.mask(281474976710597), "gDzDMygqJF");
-      equal(keymask.mask(9007199254740880), "rHBGWsprnZ");
-      equal(keymask.unmask("gDzDMygqJF"), 281474976710597);
-      equal(keymask.unmask("rHBGWsprnZ"), 9007199254740880);
+      equal(keymask.mask(281474976710597), "MTBTrVMLwD");
+      equal(keymask.mask(9007199254740880), "PvFkfyGPhH");
+      equal(keymask.unmask("MTBTrVMLwD"), 281474976710597);
+      equal(keymask.unmask("PvFkfyGPhH"), 9007199254740880);
     });
 
     it("should mask and unmask in range 11", () => {
-      equal(keymask.mask(9007199254740881n), "tYjqyhVrrvC");
-      equal(keymask.mask(288230376151711716n), "bjhNKnrQXtD");
-      equal(keymask.unmask("tYjqyhVrrvC"), 9007199254740881n);
-      equal(keymask.unmask("bjhNKnrQXtD"), 288230376151711716n);
+      equal(keymask.mask(9007199254740881n), "JdcLVNWPPRQ");
+      equal(keymask.mask(288230376151711716n), "qcNzphPnZJT");
+      equal(keymask.unmask("JdcLVNWPPRQ"), 9007199254740881n);
+      equal(keymask.unmask("qcNzphPnZJT"), 288230376151711716n);
     });
 
     it("should mask and unmask in range 12", () => {
-      equal(keymask.mask(288230376151711717n), "FYVqBfWwmsWg");
-      equal(keymask.mask(18446744073709551556n), "MmDVQkNrMRSD");
-      equal(keymask.unmask("FYVqBfWwmsWg"), 288230376151711717n);
-      equal(keymask.unmask("MmDVQkNrMRSD"), 18446744073709551556n);
+      equal(keymask.mask(288230376151711717n), "DdWLFxfjmyfM");
+      equal(keymask.mask(18446744073709551556n), "rmTWnYzPrSKT");
+      equal(keymask.unmask("DdWLFxfjmyfM"), 288230376151711717n);
+      equal(keymask.unmask("rmTWnYzPrSKT"), 18446744073709551556n);
     });
   });
 
@@ -573,86 +573,86 @@ describe("Keymask", () => {
 
     it("should mask and unmask in range 1", () => {
       equal(keymask.mask(1), "m");
-      equal(keymask.mask(40), "M");
+      equal(keymask.mask(40), "r");
       equal(keymask.unmask("m"), 1);
-      equal(keymask.unmask("M"), 40);
+      equal(keymask.unmask("r"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41), "Sb");
-      equal(keymask.mask(1020), "JV");
-      equal(keymask.unmask("Sb"), 41);
-      equal(keymask.unmask("JV"), 1020);
+      equal(keymask.mask(41), "Kq");
+      equal(keymask.mask(1020), "wW");
+      equal(keymask.unmask("Kq"), 41);
+      equal(keymask.unmask("wW"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021), "XCt");
-      equal(keymask.mask(65520), "rpv");
-      equal(keymask.unmask("XCt"), 1021);
-      equal(keymask.unmask("rpv"), 65520);
+      equal(keymask.mask(1021), "ZQJ");
+      equal(keymask.mask(65520), "PGR");
+      equal(keymask.unmask("ZQJ"), 1021);
+      equal(keymask.unmask("PGR"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521), "dCrv");
-      equal(keymask.mask(2097142), "dhrH");
-      equal(keymask.unmask("dCrv"), 65521);
-      equal(keymask.unmask("dhrH"), 2097142);
+      equal(keymask.mask(65521), "XQPR");
+      equal(keymask.mask(2097142), "XNPv");
+      equal(keymask.unmask("XQPR"), 65521);
+      equal(keymask.unmask("XNPv"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143), "qKnHS");
-      equal(keymask.mask(67108858), "gmFtM");
-      equal(keymask.unmask("qKnHS"), 2097143);
-      equal(keymask.unmask("gmFtM"), 67108858);
+      equal(keymask.mask(2097143), "LphvK");
+      equal(keymask.mask(67108858), "MmDJr");
+      equal(keymask.unmask("LphvK"), 2097143);
+      equal(keymask.unmask("MmDJr"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859), "CdBTKp");
-      equal(keymask.mask(4294967290), "HDnqhS");
-      equal(keymask.unmask("CdBTKp"), 67108859);
-      equal(keymask.unmask("HDnqhS"), 4294967290);
+      equal(keymask.mask(67108859), "QXFspG");
+      equal(keymask.mask(4294967290), "vThLNK");
+      equal(keymask.unmask("QXFspG"), 67108859);
+      equal(keymask.unmask("vThLNK"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {
-      equal(keymask.mask(4294967291), "QZtmmXn");
-      equal(keymask.mask(137438953446), "VSGJSdj");
-      equal(keymask.unmask("QZtmmXn"), 4294967291);
-      equal(keymask.unmask("VSGJSdj"), 137438953446);
+      equal(keymask.mask(4294967291), "nHJmmZh");
+      equal(keymask.mask(137438953446), "WKkwKXc");
+      equal(keymask.unmask("nHJmmZh"), 4294967291);
+      equal(keymask.unmask("WKkwKXc"), 137438953446);
     });
 
     it("should mask and unmask in range 8", () => {
-      equal(keymask.mask(137438953447), "jmFYpmhb");
-      equal(keymask.mask(4398046511092), "ZZycWTFS");
-      equal(keymask.unmask("jmFYpmhb"), 137438953447);
-      equal(keymask.unmask("ZZycWTFS"), 4398046511092);
+      equal(keymask.mask(137438953447), "cmDdGmNq");
+      equal(keymask.mask(4398046511092), "HHVtfsDK");
+      equal(keymask.unmask("cmDdGmNq"), 137438953447);
+      equal(keymask.unmask("HHVtfsDK"), 4398046511092);
     });
 
     it("should mask and unmask in range 9", () => {
-      equal(keymask.mask(4398046511093), "JjtTDrHJj");
-      equal(keymask.mask(281474976710596), "njnnsnMCB");
-      equal(keymask.unmask("JjtTDrHJj"), 4398046511093);
-      equal(keymask.unmask("njnnsnMCB"), 281474976710596);
+      equal(keymask.mask(4398046511093), "wcJsTPvwc");
+      equal(keymask.mask(281474976710596), "hchhyhrQF");
+      equal(keymask.unmask("wcJsTPvwc"), 4398046511093);
+      equal(keymask.unmask("hchhyhrQF"), 281474976710596);
     });
 
     it("should mask and unmask in range 10", () => {
-      equal(keymask.mask(281474976710597), "XnqngTcYVt");
-      equal(keymask.mask(9007199254740880), "rkjmnWqPVB");
-      equal(keymask.unmask("XnqngTcYVt"), 281474976710597);
-      equal(keymask.unmask("rkjmnWqPVB"), 9007199254740880);
+      equal(keymask.mask(281474976710597), "ZhLhMstdWJ");
+      equal(keymask.mask(9007199254740880), "PYcmhfLbWF");
+      equal(keymask.unmask("ZhLhMstdWJ"), 281474976710597);
+      equal(keymask.unmask("PYcmhfLbWF"), 9007199254740880);
     });
 
     it("should mask and unmask in range 11", () => {
-      equal(keymask.mask(9007199254740881n), "ZFPTtQhkBHr");
-      equal(keymask.mask(288230376151711716n), "JqfWVBjDqDz");
-      equal(keymask.unmask("ZFPTtQhkBHr"), 9007199254740881n);
-      equal(keymask.unmask("JqfWVBjDqDz"), 288230376151711716n);
+      equal(keymask.mask(9007199254740881n), "HDbsJnNYFvP");
+      equal(keymask.mask(288230376151711716n), "wLxfWFcTLTB");
+      equal(keymask.unmask("HDbsJnNYFvP"), 9007199254740881n);
+      equal(keymask.unmask("wLxfWFcTLTB"), 288230376151711716n);
     });
 
     it("should mask and unmask in range 12", () => {
-      equal(keymask.mask(288230376151711717n), "NjdfHBwHxXHr");
-      equal(keymask.mask(18446744073709551556n), "CJqbCdHcTmkY");
-      equal(keymask.unmask("NjdfHBwHxXHr"), 288230376151711717n);
-      equal(keymask.unmask("CJqbCdHcTmkY"), 18446744073709551556n);
+      equal(keymask.mask(288230376151711717n), "zcXxvFjvCZvP");
+      equal(keymask.mask(18446744073709551556n), "QwLqQXvtsmYd");
+      equal(keymask.unmask("zcXxvFjvCZvP"), 288230376151711717n);
+      equal(keymask.unmask("QwLqQXvtsmYd"), 18446744073709551556n);
     });
   });
 });

--- a/util/seed.js
+++ b/util/seed.js
@@ -1,5 +1,21 @@
 import { randomBytes } from "node:crypto";
+import { argv } from "node:process";
 
-console.log(randomBytes(32).toString("base64url"));
-console.log(randomBytes(24).toString("base64url"));
-console.log(randomBytes(8).toString("base64url"));
+const argv2 = argv[2];
+const argv3 = argv[3];
+let length = 32;
+let encoding = "hex";
+
+if (argv2) {
+  const i = parseInt(argv2);
+  if (isNaN(i)) {
+    encoding = argv2;
+  } else {
+    length = i;
+  }
+}
+if (argv3) {
+  encoding = argv3;
+}
+
+console.log(randomBytes(length).toString(encoding));


### PR DESCRIPTION
Use DataView instead of TypedArray when unpacking seeds to avoid inconsistencies due to machine endianness.

Update how `Base41` seed is unpacked (breaking change).

Refactor, bump version.